### PR TITLE
feat(auth): implement user authentication routes and integrate Supabase

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Build (dry run)
         uses: cloudflare/wrangler-action@v3
         with:
+          packageManager: bun
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: packages/api
@@ -63,6 +64,7 @@ jobs:
       - name: Deploy to Cloudflare Workers
         uses: cloudflare/wrangler-action@v3
         with:
+          packageManager: bun
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: packages/api

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -42,7 +42,7 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: packages/api
-          command: deploy --dry-run
+          command: deploy --dry-run --config wrangler.jsonc
 
   deploy:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -68,4 +68,4 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: packages/api
-          command: deploy
+          command: deploy --config wrangler.jsonc

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -36,6 +36,7 @@ jobs:
         run: bun install
 
       - name: Build (dry run)
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: cloudflare/wrangler-action@v3
         with:
           packageManager: bun

--- a/.github/workflows/discord-bot.yml
+++ b/.github/workflows/discord-bot.yml
@@ -34,6 +34,7 @@ jobs:
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: cloudflare/wrangler-action@v3
         with:
+          packageManager: bun
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: packages/discord-bot
@@ -56,6 +57,7 @@ jobs:
       - name: Deploy to Cloudflare Workers
         uses: cloudflare/wrangler-action@v3
         with:
+          packageManager: bun
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: packages/discord-bot

--- a/.github/workflows/discord-bot.yml
+++ b/.github/workflows/discord-bot.yml
@@ -38,7 +38,7 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: packages/discord-bot
-          command: deploy --dry-run
+          command: deploy --dry-run --config wrangler.jsonc
 
   deploy:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -61,7 +61,7 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: packages/discord-bot
-          command: deploy
+          command: deploy --config wrangler.jsonc
 
   upload-emojis:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/ingest-worker.yml
+++ b/.github/workflows/ingest-worker.yml
@@ -37,6 +37,7 @@ jobs:
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: cloudflare/wrangler-action@v3
         with:
+          packageManager: bun
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: packages/ingest-worker
@@ -126,6 +127,7 @@ jobs:
       - name: Deploy to Cloudflare Workers
         uses: cloudflare/wrangler-action@v3
         with:
+          packageManager: bun
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: packages/ingest-worker

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ dist/
 
 # Generated files
 docs/static/openapi.json
+.next/
+out/
+next-env.d.ts
 
 # Environment
 .env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ npx devvit settings set siteBaseUrl
 | `CARD_PROVIDER` | `supabase` (only; data from ingest pipeline) — set in `wrangler.jsonc` vars |
 | `SUPABASE_URL` | Supabase project URL — required |
 | `SUPABASE_SERVICE_ROLE_KEY` | Supabase service-role JWT — required |
+| `SUPABASE_ANON_KEY` | Supabase anon/public key — required for auth routes (`/api/v1/auth/*`) |
 | `UPSTASH_REDIS_REST_URL` | Upstash Redis REST URL — optional |
 | `UPSTASH_REDIS_REST_TOKEN` | Upstash Redis REST token — required when `UPSTASH_REDIS_REST_URL` is set |
 | `CORS_ORIGIN` | Comma-separated allowed origins (default: `https://riftseer.pages.dev,https://riftseer.com`) |

--- a/bun.lock
+++ b/bun.lock
@@ -37,6 +37,7 @@
       "dependencies": {
         "@elysiajs/cors": "^1.4.1",
         "@riftseer/core": "workspace:*",
+        "@supabase/supabase-js": "^2.97.0",
         "elysia": "^1.4.7",
       },
       "devDependencies": {
@@ -387,19 +388,19 @@
 
     "@chevrotain/utils": ["@chevrotain/utils@11.1.2", "", {}, "sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA=="],
 
-    "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.4.2", "", {}, "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ=="],
+    "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
 
-    "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.14.0", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": "^1.20260218.0" }, "optionalPeers": ["workerd"] }, "sha512-XKAkWhi1nBdNsSEoNG9nkcbyvfUrSjSf+VYVPfOto3gLTZVc3F4g6RASCMh6IixBKCG2yDgZKQIHGKtjcnLnKg=="],
+    "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.1", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": ">1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw=="],
 
-    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260219.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-k+xM+swQBQnkrvwobjRPxyeYwjLSludJusR0PqeHe+h6X9QIRGgw3s1AO38lXQsqzMSgG5709oOXSF19NKVVaQ=="],
+    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260507.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-S85aMwcaPJUjKWDiG6iMMnioKWtPLACa6m0j/EhHR1GYfVpnxb974cBc6d25L+sf7jHWHJI2u5hGp0UTJ7MtXQ=="],
 
-    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260219.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-EyfQdsG1KcIVAf4qndT00LZly7sLFm1VxMWHBvOFB/EVYF2sE5HZ0dPbe+yrax5p3eS0oLZthR8ynhz4UulMUQ=="],
+    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260507.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-GMEBu8Zp9Q97HLnf7bWJN4KjWpN5MxpeqdvHjBGWNl8UYprJI0k+Jkp89+Wh5S8vIon+HoVbDfOzPa7VwgL6Eg=="],
 
-    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260219.0", "", { "os": "linux", "cpu": "x64" }, "sha512-N0UHXILYYa6htFO/uC92uAqusvynbSbOcHcrVXMKqP9Jy7eqXGMovyKIrNgzYnKIszNB+0lfUYdGI3Wci07LuA=="],
+    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260507.1", "", { "os": "linux", "cpu": "x64" }, "sha512-QlrKEBdgA3uVc0Ok0Q3+0/CW0CTjgj5ySir1i1YY5FXVv0X6GpwtnB5umjunjF2MFprss+L+iFGZzxcSvMC1nA=="],
 
-    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260219.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-835pjQ9uuAtwPBOAkPf+oxH3mNE5mqWuE3H7hJsul7WZsRD2FDcariyoT2AW6xyOePILrn4uMnmG1KGc9m/8Pg=="],
+    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260507.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-eGbbupEtK2nh9V9Dhcx3vv3GTKeXqSVNgAEYVCCN0NGS9tl9HbMoHRX/4JL181FKXROMigWBCQVL//qPhsAzBQ=="],
 
-    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260219.0", "", { "os": "win32", "cpu": "x64" }, "sha512-i7qcuOsuAxqqn1n5Ar3Rh1dHUL9vNmpF9FcdMTT84jIrdm5UNrPZz5grJthPmpB9LTcreT9iiP6qKbzGjnCwPA=="],
+    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260507.1", "", { "os": "win32", "cpu": "x64" }, "sha512-dmClJ/E0BAcuDetQIZFqbeAXejWrG5pysGRMQ6T83Y0IW/7IAamY2zFEkAJ10I5xwZsdHuYsZtzlOxpEXpJs7A=="],
 
     "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260219.0", "", {}, "sha512-jL2BNnDqbKXDrxhtKx+wVmQpv/P6w8J4WVFiuT9OMEPsw8V2TfTozoWTcCZ2AhE09yK406xQFE4mBq9IIgobuw=="],
 
@@ -895,17 +896,19 @@
 
     "@speed-highlight/core": ["@speed-highlight/core@1.2.14", "", {}, "sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA=="],
 
-    "@supabase/auth-js": ["@supabase/auth-js@2.97.0", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-2Og/1lqp+AIavr8qS2X04aSl8RBY06y4LrtIAGxat06XoXYiDxKNQMQzWDAKm1EyZFZVRNH48DO5YvIZ7la5fQ=="],
+    "@supabase/auth-js": ["@supabase/auth-js@2.105.4", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-Ejfa37M5xoIwoxVebxRahnwubPo8g22qkXQ4p50+N9MIvU9UZoN+A8dwVPtczzGf8oV/YXN80ZPxK4aWXuSN/A=="],
 
-    "@supabase/functions-js": ["@supabase/functions-js@2.97.0", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-fSaA0ZeBUS9hMgpGZt5shIZvfs3Mvx2ZdajQT4kv/whubqDBAp3GU5W8iIXy21MRvKmO2NpAj8/Q6y+ZkZyF/w=="],
+    "@supabase/functions-js": ["@supabase/functions-js@2.105.4", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-JVNKbBft3Qkja+WlGaE026AJ2AH9K0UTsxsfvEIHgd4zFrBor4BYRCrYFrv9IDsvVqkF72wKDsODJl5GY/C4tA=="],
 
-    "@supabase/postgrest-js": ["@supabase/postgrest-js@2.97.0", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-g4Ps0eaxZZurvfv/KGoo2XPZNpyNtjth9aW8eho9LZWM0bUuBtxPZw3ZQ6ERSpEGogshR+XNgwlSPIwcuHCNww=="],
+    "@supabase/phoenix": ["@supabase/phoenix@0.4.2", "", {}, "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A=="],
 
-    "@supabase/realtime-js": ["@supabase/realtime-js@2.97.0", "", { "dependencies": { "@types/phoenix": "^1.6.6", "@types/ws": "^8.18.1", "tslib": "2.8.1", "ws": "^8.18.2" } }, "sha512-37Jw0NLaFP0CZd7qCan97D1zWutPrTSpgWxAw6Yok59JZoxp4IIKMrPeftJ3LZHmf+ILQOPy3i0pRDHM9FY36Q=="],
+    "@supabase/postgrest-js": ["@supabase/postgrest-js@2.105.4", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-SppIyLo/kTwIlz1qpv2HN1EQqBg0GVktrDDFsXygYROha3MgVn4rT7p5EjFHFqXQm2rdRGb/BI7bc+jr10m91w=="],
 
-    "@supabase/storage-js": ["@supabase/storage-js@2.97.0", "", { "dependencies": { "iceberg-js": "^0.8.1", "tslib": "2.8.1" } }, "sha512-9f6NniSBfuMxOWKwEFb+RjJzkfMdJUwv9oHuFJKfe/5VJR8cd90qw68m6Hn0ImGtwG37TUO+QHtoOechxRJ1Yg=="],
+    "@supabase/realtime-js": ["@supabase/realtime-js@2.105.4", "", { "dependencies": { "@supabase/phoenix": "^0.4.2", "tslib": "2.8.1" } }, "sha512-6ov6c59+8D9h7q4M4Gy/uDJlC0Akxl9/714Y+6vJ+Sijuc16TS/p5DwhfRCLNcIhNiej1gEt+CQUwsjiPt4PxQ=="],
 
-    "@supabase/supabase-js": ["@supabase/supabase-js@2.97.0", "", { "dependencies": { "@supabase/auth-js": "2.97.0", "@supabase/functions-js": "2.97.0", "@supabase/postgrest-js": "2.97.0", "@supabase/realtime-js": "2.97.0", "@supabase/storage-js": "2.97.0" } }, "sha512-kTD91rZNO4LvRUHv4x3/4hNmsEd2ofkYhuba2VMUPRVef1RCmnHtm7rIws38Fg0yQnOSZOplQzafn0GSiy6GVg=="],
+    "@supabase/storage-js": ["@supabase/storage-js@2.105.4", "", { "dependencies": { "iceberg-js": "^0.8.1", "tslib": "2.8.1" } }, "sha512-Jx+pzMP1Whjof2PWHoVBUA75/p7PQE9CqKBzn1oXVyJDOggMLSH2OzVWwsXYaxEpdC1K/KltwmOX44nL3LHl9g=="],
+
+    "@supabase/supabase-js": ["@supabase/supabase-js@2.105.4", "", { "dependencies": { "@supabase/auth-js": "2.105.4", "@supabase/functions-js": "2.105.4", "@supabase/postgrest-js": "2.105.4", "@supabase/realtime-js": "2.105.4", "@supabase/storage-js": "2.105.4" } }, "sha512-cEnx+k49knU+qdIP7rXwR6fqEXPHZs+74xFK1R0S8MgQ7v9tbePVdGxvO03n3bPympMdJWVLadARBfU4TgNHCQ=="],
 
     "@svgr/babel-plugin-add-jsx-attribute": ["@svgr/babel-plugin-add-jsx-attribute@8.0.0", "", { "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g=="],
 
@@ -1098,8 +1101,6 @@
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
     "@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
-
-    "@types/phoenix": ["@types/phoenix@1.6.7", "", {}, "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q=="],
 
     "@types/prismjs": ["@types/prismjs@1.26.6", "", {}, "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw=="],
 
@@ -2177,7 +2178,7 @@
 
     "mini-css-extract-plugin": ["mini-css-extract-plugin@2.10.2", "", { "dependencies": { "schema-utils": "^4.0.0", "tapable": "^2.2.1" }, "peerDependencies": { "webpack": "^5.0.0" } }, "sha512-AOSS0IdEB95ayVkxn5oGzNQwqAi2J0Jb/kKm43t7H73s8+f5873g0yuj0PNvK4dO75mu5DHg4nlgp4k6Kga8eg=="],
 
-    "miniflare": ["miniflare@4.20260219.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.18.2", "workerd": "1.20260219.0", "ws": "8.18.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-EIb5wXbWUnnC60XU2aiFOPNd4fgTXzECkwRSOXZ1vdcY9WZaEE9rVf+h+Apw+WkOHRkp3Dr9/ZhQ5y1R+9iZ4Q=="],
+    "miniflare": ["miniflare@4.20260507.1", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.24.8", "workerd": "1.20260507.1", "ws": "8.18.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-PSXBiLExTdZ4UGO/raKCHQauUpYL7F880ZRB7j0+78Rv8h7TsdN2E/iEDK9sK2Y+SPQ5wJSeAa+rDeVKoZZoEw=="],
 
     "minimalistic-assert": ["minimalistic-assert@1.0.1", "", {}, "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="],
 
@@ -2725,9 +2726,9 @@
 
     "svgo": ["svgo@3.3.3", "", { "dependencies": { "commander": "^7.2.0", "css-select": "^5.1.0", "css-tree": "^2.3.1", "css-what": "^6.1.0", "csso": "^5.0.5", "picocolors": "^1.0.0", "sax": "^1.5.0" }, "bin": "./bin/svgo" }, "sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng=="],
 
-    "tailwind-merge": ["tailwind-merge@3.4.1", "", {}, "sha512-2OA0rFqWOkITEAOFWSBSApYkDeH9t2B3XSJuI4YztKBzK3mX0737A2qtxDZ7xkw9Zfh0bWl+r34sF3HXV+Ig7Q=="],
+    "tailwind-merge": ["tailwind-merge@3.5.0", "", {}, "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A=="],
 
-    "tailwindcss": ["tailwindcss@4.2.0", "", {}, "sha512-yYzTZ4++b7fNYxFfpnberEEKu43w44aqDMNM9MHMmcKuCH7lL8jJ4yJ7LGHv7rSwiqM0nkiobF9I6cLlpS2P7Q=="],
+    "tailwindcss": ["tailwindcss@4.2.4", "", {}, "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA=="],
 
     "tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
 
@@ -2783,7 +2784,7 @@
 
     "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
 
-    "undici": ["undici@7.18.2", "", {}, "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw=="],
+    "undici": ["undici@7.24.8", "", {}, "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
@@ -2891,15 +2892,15 @@
 
     "wildcard": ["wildcard@2.0.1", "", {}, "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ=="],
 
-    "workerd": ["workerd@1.20260219.0", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260219.0", "@cloudflare/workerd-darwin-arm64": "1.20260219.0", "@cloudflare/workerd-linux-64": "1.20260219.0", "@cloudflare/workerd-linux-arm64": "1.20260219.0", "@cloudflare/workerd-windows-64": "1.20260219.0" }, "bin": { "workerd": "bin/workerd" } }, "sha512-l4U4iT5H8jNV6+EK23ExnUV2z6JvqQtQPrT8XCm4G8RpwC9EPpYTOO9s/ImMPJKe1WSbQUQoJ4k8Nd83fz8skQ=="],
+    "workerd": ["workerd@1.20260507.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260507.1", "@cloudflare/workerd-darwin-arm64": "1.20260507.1", "@cloudflare/workerd-linux-64": "1.20260507.1", "@cloudflare/workerd-linux-arm64": "1.20260507.1", "@cloudflare/workerd-windows-64": "1.20260507.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-z7JhsFSe6+X1b5fUHaVpo15VM1IRMJiLofEkq8iKdCo+Veqc+FUg5lIsuz8NwePxuSKrXtO4ZQpGkQLbPVXFhg=="],
 
-    "wrangler": ["wrangler@4.67.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.14.0", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260219.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260219.0" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260219.0" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-58OoVth7bqm0nqsRgcI67gHbpp0IfR1JIBqDY0XR1FzRu9Qkjn6v2iJAdFf82QcVBFhaMBYQi88WqYGswq5wlQ=="],
+    "wrangler": ["wrangler@4.90.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260507.1", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260507.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260507.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-bmNIykl59TfCUn5xQgU7IWylSsPx3LQaPLMSAq2VQHt89CBrcj9qXQ0eYfjBCWA5XTBVgten391evt7xxtXwcA=="],
 
     "wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
     "write-file-atomic": ["write-file-atomic@3.0.3", "", { "dependencies": { "imurmurhash": "^0.1.4", "is-typedarray": "^1.0.0", "signal-exit": "^3.0.2", "typedarray-to-buffer": "^3.1.5" } }, "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q=="],
 
-    "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+    "ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 
     "wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
 
@@ -2908,6 +2909,8 @@
     "xml-js": ["xml-js@1.6.11", "", { "dependencies": { "sax": "^1.2.4" }, "bin": { "xml-js": "./bin/cli.js" } }, "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "yaml": ["yaml@2.8.4", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog=="],
 
     "yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
 
@@ -2979,6 +2982,8 @@
 
     "@scalar/themes/@scalar/types": ["@scalar/types@0.1.7", "", { "dependencies": { "@scalar/openapi-types": "0.2.0", "@unhead/schema": "^1.11.11", "nanoid": "^5.1.5", "type-fest": "^4.20.0", "zod": "^3.23.8" } }, "sha512-irIDYzTQG2KLvFbuTI8k2Pz/R4JR+zUUSykVTbEMatkzMmVFnn1VzNSMlODbadycwZunbnL2tA27AXed9URVjw=="],
 
+    "@tailwindcss/node/tailwindcss": ["tailwindcss@4.2.0", "", {}, "sha512-yYzTZ4++b7fNYxFfpnberEEKu43w44aqDMNM9MHMmcKuCH7lL8jJ4yJ7LGHv7rSwiqM0nkiobF9I6cLlpS2P7Q=="],
+
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
@@ -2990,6 +2995,8 @@
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@tailwindcss/vite/tailwindcss": ["tailwindcss@4.2.0", "", {}, "sha512-yYzTZ4++b7fNYxFfpnberEEKu43w44aqDMNM9MHMmcKuCH7lL8jJ4yJ7LGHv7rSwiqM0nkiobF9I6cLlpS2P7Q=="],
 
     "accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
@@ -3221,8 +3228,6 @@
 
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
-    "miniflare/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
-
     "mlly/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "node-emoji/@sindresorhus/is": ["@sindresorhus/is@4.6.0", "", {}, "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="],
@@ -3312,6 +3317,8 @@
     "webpack-dev-middleware/range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
 
     "webpack-dev-server/open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
+
+    "webpack-dev-server/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
     "webpackbar/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -44,6 +44,7 @@
         "@cloudflare/workers-types": "^4.0.0",
         "@elysiajs/swagger": "^1.3.0",
         "bun-types": "^1.2.0",
+        "wrangler": "^4",
       },
     },
     "packages/core": {

--- a/packages/api/.dev.vars.example
+++ b/packages/api/.dev.vars.example
@@ -4,6 +4,7 @@
 
 SUPABASE_URL=https://<project-ref>.supabase.co
 SUPABASE_SERVICE_ROLE_KEY=<service-role-key>
+SUPABASE_ANON_KEY=<anon-public>
 
 # Optional — leave blank to disable Redis
 UPSTASH_REDIS_REST_URL=

--- a/packages/api/CLAUDE.md
+++ b/packages/api/CLAUDE.md
@@ -42,6 +42,7 @@ See [`packages/api/docs/`](./docs/) for endpoint reference:
 - [`search.md`](./docs/search.md) — `GET /cards` search mechanics, params, fuzzy/autocomplete
 - [`decks.md`](./docs/decks.md) — deck short-form endpoints
 - [`meta.md`](./docs/meta.md) — health and provider state
+- [`auth.md`](./docs/auth.md) — register, login, refresh, logout
 
 ## Elysia Patterns
 - Define routes on the versioned sub-app (`v1`, `v2`, …), not directly on the root app
@@ -72,7 +73,10 @@ const json = await res.json()
 ## Cloudflare Workers Notes
 - `@elysiajs/swagger` is NOT included — it requires `fs` which is unavailable on CF Workers
 - `process.env` is populated from worker vars/secrets via the `nodejs_compat` flag
-- Secrets set with `wrangler secret put`: `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`
+- Secrets set with `wrangler secret put`: `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_ANON_KEY`, `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`
+- Auth routes (`/api/v1/auth/*`) skip card provider warmup and do not require `SUPABASE_SERVICE_ROLE_KEY` — they use `SUPABASE_ANON_KEY` via `@supabase/supabase-js` (register/login/refresh) or direct Supabase REST (logout)
+- **Protected routes**: use `authPlugin` from `src/plugins/auth.ts` — `.use(authPlugin)` injects `user: User` into the handler context via `.resolve({ as: 'scoped' })`. Scope is `scoped` so the middleware only runs for routes in the Elysia instance that explicitly uses the plugin; public routes in the same chain are unaffected. The shared Supabase client lives in `src/lib/supabase.ts`
+- **In Elysia v1.4.x**: use `status(code, body)` (not `error(code, body)`) to return early responses from `resolve`/`derive` — the context has `status`, not `error`
 - CF Workers forbid async I/O (fetch) in global scope — `warmup()` is deferred to the first request via `onBeforeHandle` using a lazy promise singleton (retries on failure)
 - `setInterval` in `warmup()` may not persist across isolate recycles; `/meta` stats can be stale after a cold start
 
@@ -80,6 +84,7 @@ const json = await res.json()
 - `elysia` — server framework (with CloudflareAdapter)
 - `@elysiajs/cors` — CORS headers
 - `@riftseer/core` — workspace dep (provider, types)
+- `@supabase/supabase-js` — Supabase client used by auth routes
 
 ## Testing
 ```bash

--- a/packages/api/docs/auth.md
+++ b/packages/api/docs/auth.md
@@ -107,7 +107,7 @@ Invalidates the current session server-side. Both the access token and refresh t
 
 **Headers**
 
-```
+```http
 Authorization: Bearer <access_token>
 ```
 
@@ -132,7 +132,7 @@ Returns the authenticated user's profile. Used by clients to restore a session o
 
 **Headers**
 
-```
+```http
 Authorization: Bearer <access_token>
 ```
 

--- a/packages/api/docs/auth.md
+++ b/packages/api/docs/auth.md
@@ -1,0 +1,150 @@
+---
+title: Auth
+sidebar_label: Auth
+sidebar_position: 6
+---
+
+Auth endpoints let clients register users and manage sessions using Supabase Auth. All routes are under `/api/v1/auth`.
+
+Protected routes require a valid `Authorization: Bearer <access_token>` header. The access token is returned by `login`, `register`, or `refresh`.
+
+Sessions consist of a short-lived **access token** (JWT, 1 hour by default) and a long-lived **refresh token**. Store both securely; only the access token should be sent with API requests.
+
+---
+
+## POST /api/v1/auth/register
+
+Creates a new user account.
+
+**Request body**
+
+```json
+{ "email": "user@example.com", "password": "hunter2!!" }
+```
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `email` | string | yes | |
+| `password` | string | yes | Min 8 characters |
+
+**Responses**
+
+| Status | Meaning |
+|--------|---------|
+| `200` | Account created; returns a session (email confirmation disabled) |
+| `202` | Account created; confirmation email sent — no session until confirmed |
+| `400` | Validation error or account already exists |
+
+**200 body**
+
+```json
+{
+  "access_token": "eyJ...",
+  "refresh_token": "...",
+  "expires_in": 3600,
+  "token_type": "bearer",
+  "user": { "id": "uuid", "email": "user@example.com", "created_at": "2026-01-01T00:00:00Z" }
+}
+```
+
+**202 body**
+
+```json
+{
+  "message": "Check your email to confirm your account before signing in.",
+  "code": "EMAIL_CONFIRMATION_REQUIRED"
+}
+```
+
+---
+
+## POST /api/v1/auth/login
+
+Authenticates with email and password.
+
+**Request body**
+
+```json
+{ "email": "user@example.com", "password": "hunter2!!" }
+```
+
+**Responses**
+
+| Status | Meaning |
+|--------|---------|
+| `200` | Returns a session |
+| `400` | Missing fields or malformed request |
+| `401` | Invalid credentials or unconfirmed email |
+
+**200 body** — same shape as `register` 200.
+
+---
+
+## POST /api/v1/auth/refresh
+
+Exchanges a refresh token for a new access token and refresh token. Refresh tokens are rotated on each use — store the new pair returned by this endpoint.
+
+**Request body**
+
+```json
+{ "refresh_token": "..." }
+```
+
+**Responses**
+
+| Status | Meaning |
+|--------|---------|
+| `200` | Returns a new session |
+| `401` | Refresh token invalid or expired |
+
+**200 body** — same shape as `register` 200.
+
+---
+
+## POST /api/v1/auth/logout
+
+Invalidates the current session server-side. Both the access token and refresh token are revoked.
+
+**Headers**
+
+```
+Authorization: Bearer <access_token>
+```
+
+**Responses**
+
+| Status | Meaning |
+|--------|---------|
+| `200` | Session revoked |
+| `401` | Missing or invalid `Authorization` header |
+
+**200 body**
+
+```json
+{ "message": "Logged out successfully" }
+```
+
+---
+
+## GET /api/v1/auth/me
+
+Returns the authenticated user's profile. Used by clients to restore a session on page load.
+
+**Headers**
+
+```
+Authorization: Bearer <access_token>
+```
+
+**Responses**
+
+| Status | Meaning |
+|--------|---------|
+| `200` | Returns user profile |
+| `401` | Missing or invalid token |
+
+**200 body**
+
+```json
+{ "id": "uuid", "email": "user@example.com", "created_at": "2026-01-01T00:00:00Z" }
+```

--- a/packages/api/docs/index.md
+++ b/packages/api/docs/index.md
@@ -13,7 +13,7 @@ The Riftseer API is a read-mostly REST API that exposes Riftbound TCG card data.
 
 ## Authentication
 
-No authentication is required. All endpoints are publicly accessible.
+Most endpoints are publicly accessible and require no authentication. The `/api/v1/auth` endpoints manage user sessions; authenticated requests should include `Authorization: Bearer <access_token>` where required.
 
 ---
 
@@ -65,10 +65,9 @@ Errors return a JSON body with `error` (human-readable message) and `code` (mach
 | Status | Meaning |
 | --- | --- |
 | `400` | Bad request — missing or invalid parameter |
+| `401` | Unauthenticated — missing or invalid token (auth routes only) |
 | `404` | Resource not found |
 | `500` | Internal server error |
-
-There is no 401 or 403 — the API has no authentication layer.
 
 ---
 
@@ -109,6 +108,7 @@ Route modules live in `packages/api/src/routes/`:
 | `cards.ts` | `/cards`, `/cards/random`, `/cards/:id`, `/cards/:id/text`, `/cards/resolve` |
 | `sets.ts` | `/sets` |
 | `decks.ts` | `/decks/u`, `/decks/u/:shortForm` |
+| `auth.ts` | `/auth/register`, `/auth/login`, `/auth/refresh`, `/auth/logout` |
 
 ---
 
@@ -145,3 +145,8 @@ This means the API has no opinion on where data comes from — swapping the prov
 | `GET` | `/api/v1/decks/u/:shortForm` | [Decks](./decks.md) |
 | `POST` | `/api/v1/decks/u/:shortForm` | [Decks](./decks.md) |
 | `POST` | `/api/v1/decks/u` | [Decks](./decks.md) |
+| `POST` | `/api/v1/auth/register` | [Auth](./auth.md) |
+| `POST` | `/api/v1/auth/login` | [Auth](./auth.md) |
+| `POST` | `/api/v1/auth/refresh` | [Auth](./auth.md) |
+| `POST` | `/api/v1/auth/logout` | [Auth](./auth.md) |
+| `GET` | `/api/v1/auth/me` | [Auth](./auth.md) |

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.0.0",
     "@elysiajs/swagger": "^1.3.0",
-    "bun-types": "^1.2.0"
+    "bun-types": "^1.2.0",
+    "wrangler": "^4"
   }
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@elysiajs/cors": "^1.4.1",
     "@riftseer/core": "workspace:*",
+    "@supabase/supabase-js": "^2.97.0",
     "elysia": "^1.4.7"
   },
   "devDependencies": {

--- a/packages/api/scripts/generate-spec.ts
+++ b/packages/api/scripts/generate-spec.ts
@@ -23,6 +23,7 @@ import { metaRoutes } from "../src/routes/meta";
 import { cardsRoutes } from "../src/routes/cards";
 import { setsRoutes } from "../src/routes/sets";
 import { decksRoutes } from "../src/routes/decks";
+import { authRoutes } from "../src/routes/auth";
 
 const cardProvider = createProvider();
 try {
@@ -46,7 +47,8 @@ const app = new Elysia()
       .use(metaRoutes(cardProvider, Date.now()))
       .use(cardsRoutes(cardProvider))
       .use(setsRoutes(cardProvider))
-      .use(decksRoutes(deckProvider)),
+      .use(decksRoutes(deckProvider))
+      .use(authRoutes()),
   )
   .use(
     swagger({
@@ -58,6 +60,7 @@ const app = new Elysia()
           { name: "Cards", description: "Card lookup and search" },
           { name: "Sets", description: "Card set listing" },
           { name: "Decks", description: "Deck building and sharing" },
+          { name: "Auth", description: "User registration and session management" },
         ],
       },
     }),

--- a/packages/api/src/__tests__/routes/decks.test.ts
+++ b/packages/api/src/__tests__/routes/decks.test.ts
@@ -4,7 +4,20 @@
  * or card lookups happen.
  */
 
-import { describe, it, expect, beforeAll } from "bun:test";
+import { describe, it, expect, beforeAll, mock } from "bun:test";
+
+mock.module("../../lib/supabase", () => ({
+  supabaseUrl: "http://localhost",
+  supabaseAnonKey: "test-key",
+  authClient: {
+    auth: {
+      getUser: async (_token: string) => ({
+        data: { user: { id: "test-user-id", email: "test@example.com" } },
+        error: null,
+      }),
+    },
+  },
+}));
 import { Elysia } from "elysia";
 import { swagger } from "@elysiajs/swagger";
 import type { SimplifiedDeck, SimplifiedDeckProvider } from "@riftseer/core";
@@ -111,7 +124,7 @@ describe("Deck routes", () => {
       const res = await app.handle(
         new Request(`http://localhost/api/v1/decks/u/${VALID_SHORT_FORM}`, {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: { "Content-Type": "application/json", Authorization: "Bearer test-token" },
           body: JSON.stringify({}),
         }),
       );
@@ -124,7 +137,7 @@ describe("Deck routes", () => {
       const res = await app.handle(
         new Request(`http://localhost/api/v1/decks/u/${VALID_SHORT_FORM}`, {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: { "Content-Type": "application/json", Authorization: "Bearer test-token" },
           body: JSON.stringify({
             cardsToAdd: ["aaaaaaaa-0000-0000-0000-000000000001:1"],
           }),
@@ -140,7 +153,7 @@ describe("Deck routes", () => {
       const res = await app.handle(
         new Request(`http://localhost/api/v1/decks/u/${VALID_SHORT_FORM}`, {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: { "Content-Type": "application/json", Authorization: "Bearer test-token" },
           body: JSON.stringify({
             cardsToRemove: ["bf1bafdc-2739-469b-bde6-c24a868f4979:2"],
           }),
@@ -156,7 +169,7 @@ describe("Deck routes", () => {
       const res = await app.handle(
         new Request(`http://localhost/api/v1/decks/u/${VALID_SHORT_FORM}`, {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: { "Content-Type": "application/json", Authorization: "Bearer test-token" },
           body: JSON.stringify({ cardsToAdd: ["notavalidentry"] }),
         }),
       );
@@ -167,7 +180,7 @@ describe("Deck routes", () => {
       const res = await app.handle(
         new Request("http://localhost/api/v1/decks/u/badinput", {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: { "Content-Type": "application/json", Authorization: "Bearer test-token" },
           body: JSON.stringify({ cardsToAdd: ["bf1bafdc-2739-469b-bde6-c24a868f4979:1"] }),
         }),
       );
@@ -182,7 +195,7 @@ describe("Deck routes", () => {
       const res = await app.handle(
         new Request("http://localhost/api/v1/decks/u", {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: { "Content-Type": "application/json", Authorization: "Bearer test-token" },
           body: JSON.stringify({
             cardsToAdd: ["bf1bafdc-2739-469b-bde6-c24a868f4979:2"],
           }),
@@ -198,7 +211,7 @@ describe("Deck routes", () => {
       const res = await app.handle(
         new Request("http://localhost/api/v1/decks/u", {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: { "Content-Type": "application/json", Authorization: "Bearer test-token" },
           body: JSON.stringify({}),
         }),
       );
@@ -211,7 +224,7 @@ describe("Deck routes", () => {
       const res = await app.handle(
         new Request("http://localhost/api/v1/decks/u", {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: { "Content-Type": "application/json", Authorization: "Bearer test-token" },
           body: JSON.stringify({
             cardsToAdd: ["bf1bafdc-2739-469b-bde6-c24a868f4979:1"],
             cardsToRemove: ["bf1bafdc-2739-469b-bde6-c24a868f4979:1"],
@@ -227,7 +240,7 @@ describe("Deck routes", () => {
       const res = await app.handle(
         new Request("http://localhost/api/v1/decks/u", {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: { "Content-Type": "application/json", Authorization: "Bearer test-token" },
           body: JSON.stringify({ cardsToAdd: ["notavalidentry"] }),
         }),
       );

--- a/packages/api/src/__tests__/routes/decks.test.ts
+++ b/packages/api/src/__tests__/routes/decks.test.ts
@@ -11,10 +11,10 @@ mock.module("../../lib/supabase", () => ({
   supabaseAnonKey: "test-key",
   authClient: {
     auth: {
-      getUser: async (_token: string) => ({
-        data: { user: { id: "test-user-id", email: "test@example.com" } },
-        error: null,
-      }),
+      getUser: async (token: string) =>
+        token === "test-token"
+          ? { data: { user: { id: "test-user-id", email: "test@example.com" } }, error: null }
+          : { data: { user: null }, error: null },
     },
   },
 }));
@@ -120,6 +120,28 @@ describe("Deck routes", () => {
   // ── POST /decks/u/:shortForm ──────────────────────────────────────────────
 
   describe("POST /decks/u/:shortForm", () => {
+    it("returns 401 when Authorization header is missing", async () => {
+      const res = await app.handle(
+        new Request(`http://localhost/api/v1/decks/u/${VALID_SHORT_FORM}`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ cardsToAdd: ["bf1bafdc-2739-469b-bde6-c24a868f4979:1"] }),
+        }),
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 401 when Authorization token is invalid", async () => {
+      const res = await app.handle(
+        new Request(`http://localhost/api/v1/decks/u/${VALID_SHORT_FORM}`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Authorization: "Bearer bad-token" },
+          body: JSON.stringify({ cardsToAdd: ["bf1bafdc-2739-469b-bde6-c24a868f4979:1"] }),
+        }),
+      );
+      expect(res.status).toBe(401);
+    });
+
     it("returns 400 when no cardsToAdd or cardsToRemove provided", async () => {
       const res = await app.handle(
         new Request(`http://localhost/api/v1/decks/u/${VALID_SHORT_FORM}`, {
@@ -191,6 +213,28 @@ describe("Deck routes", () => {
   // ── POST /decks/u ─────────────────────────────────────────────────────────
 
   describe("POST /decks/u", () => {
+    it("returns 401 when Authorization header is missing", async () => {
+      const res = await app.handle(
+        new Request("http://localhost/api/v1/decks/u", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ cardsToAdd: ["bf1bafdc-2739-469b-bde6-c24a868f4979:1"] }),
+        }),
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 401 when Authorization token is invalid", async () => {
+      const res = await app.handle(
+        new Request("http://localhost/api/v1/decks/u", {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Authorization: "Bearer bad-token" },
+          body: JSON.stringify({ cardsToAdd: ["bf1bafdc-2739-469b-bde6-c24a868f4979:1"] }),
+        }),
+      );
+      expect(res.status).toBe(401);
+    });
+
     it("creates a new deck with the provided cards", async () => {
       const res = await app.handle(
         new Request("http://localhost/api/v1/decks/u", {

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -13,11 +13,16 @@
  *   GET  /api/v1/decks/u/:shortForm
  *   POST /api/v1/decks/u/:shortForm
  *   POST /api/v1/decks/u
+ *   POST /api/v1/auth/register  body: { email, password }
+ *   POST /api/v1/auth/login     body: { email, password }
+ *   POST /api/v1/auth/refresh   body: { refresh_token }
+ *   POST /api/v1/auth/logout    Authorization: Bearer <access_token>
+ *   GET  /api/v1/auth/me        Authorization: Bearer <access_token>  (protected)
  *
  * Deploy: wrangler deploy
  * Dev:    wrangler dev
  * Secrets (wrangler secret put): SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY,
- *   UPSTASH_REDIS_REST_URL, UPSTASH_REDIS_REST_TOKEN
+ *   SUPABASE_ANON_KEY, UPSTASH_REDIS_REST_URL, UPSTASH_REDIS_REST_TOKEN
  */
 
 import { Elysia } from "elysia";
@@ -33,6 +38,7 @@ import { metaRoutes } from "./routes/meta";
 import { cardsRoutes } from "./routes/cards";
 import { setsRoutes } from "./routes/sets";
 import { decksRoutes } from "./routes/decks";
+import { authRoutes } from "./routes/auth";
 
 // ─── Singletons ───────────────────────────────────────────────────────────────
 // CF Workers forbid async I/O (fetch) in global scope — only inside handlers.
@@ -67,7 +73,7 @@ function ensureWarmedUp(): Promise<void> {
 
 export const app = new Elysia({ adapter: CloudflareAdapter })
   .onBeforeHandle(async ({ path, set }) => {
-    if (path === "/api/v1/health") return;
+    if (path === "/api/v1/health" || path.startsWith("/api/v1/auth/")) return;
     try {
       await ensureWarmedUp();
     } catch {
@@ -86,7 +92,8 @@ export const app = new Elysia({ adapter: CloudflareAdapter })
       .use(metaRoutes(cardProvider, startTime))
       .use(cardsRoutes(cardProvider))
       .use(setsRoutes(cardProvider))
-      .use(decksRoutes(deckProvider)),
+      .use(decksRoutes(deckProvider))
+      .use(authRoutes()),
   )
   .compile();
 

--- a/packages/api/src/lib/supabase.ts
+++ b/packages/api/src/lib/supabase.ts
@@ -1,0 +1,11 @@
+import { createClient } from "@supabase/supabase-js";
+
+export const supabaseUrl = process.env.SUPABASE_URL ?? "";
+export const supabaseAnonKey = process.env.SUPABASE_ANON_KEY ?? "";
+
+export const authClient =
+  supabaseUrl && supabaseAnonKey
+    ? createClient(supabaseUrl, supabaseAnonKey, {
+        auth: { autoRefreshToken: false, persistSession: false },
+      })
+    : null;

--- a/packages/api/src/plugins/auth.ts
+++ b/packages/api/src/plugins/auth.ts
@@ -1,0 +1,21 @@
+import { Elysia } from "elysia";
+import { authClient } from "../lib/supabase";
+
+export const authPlugin = new Elysia({ name: "auth" })
+  .resolve({ as: "scoped" }, async ({ headers, status }) => {
+    if (!authClient) {
+      return status(503, { error: "Auth service unavailable", code: "SERVICE_UNAVAILABLE" });
+    }
+    const token = headers.authorization?.slice(7);
+    if (!token) {
+      return status(401, { error: "Missing or invalid Authorization header", code: "MISSING_TOKEN" });
+    }
+    const {
+      data: { user },
+      error: authError,
+    } = await authClient.auth.getUser(token);
+    if (authError || !user) {
+      return status(401, { error: "Invalid or expired token", code: "INVALID_TOKEN" });
+    }
+    return { user };
+  });

--- a/packages/api/src/plugins/auth.ts
+++ b/packages/api/src/plugins/auth.ts
@@ -10,10 +10,12 @@ export const authPlugin = new Elysia({ name: "auth" })
     if (!token) {
       return status(401, { error: "Missing or invalid Authorization header", code: "MISSING_TOKEN" });
     }
-    const {
-      data: { user },
-      error: authError,
-    } = await authClient.auth.getUser(token);
+    let user, authError;
+    try {
+      ({ data: { user }, error: authError } = await authClient.auth.getUser(token));
+    } catch {
+      return status(503, { error: "Auth service unavailable", code: "SERVICE_UNAVAILABLE" });
+    }
     if (authError || !user) {
       return status(401, { error: "Invalid or expired token", code: "INVALID_TOKEN" });
     }

--- a/packages/api/src/plugins/optional-auth.ts
+++ b/packages/api/src/plugins/optional-auth.ts
@@ -5,6 +5,10 @@ export const optionalAuthPlugin = new Elysia({ name: "optional-auth" })
   .derive({ as: "scoped" }, async ({ headers }) => {
     const token = headers.authorization?.slice(7);
     if (!token || !authClient) return { user: null };
-    const { data: { user } } = await authClient.auth.getUser(token);
-    return { user };
+    try {
+      const { data: { user } } = await authClient.auth.getUser(token);
+      return { user };
+    } catch {
+      return { user: null };
+    }
   });

--- a/packages/api/src/plugins/optional-auth.ts
+++ b/packages/api/src/plugins/optional-auth.ts
@@ -1,0 +1,10 @@
+import { Elysia } from "elysia";
+import { authClient } from "../lib/supabase";
+
+export const optionalAuthPlugin = new Elysia({ name: "optional-auth" })
+  .derive({ as: "scoped" }, async ({ headers }) => {
+    const token = headers.authorization?.slice(7);
+    if (!token || !authClient) return { user: null };
+    const { data: { user } } = await authClient.auth.getUser(token);
+    return { user };
+  });

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -1,0 +1,266 @@
+import { Elysia, t } from "elysia";
+import { authClient, supabaseUrl, supabaseAnonKey } from "../lib/supabase";
+import { authPlugin } from "../plugins/auth";
+import { ErrorSchema } from "../schemas";
+
+const SessionSchema = t.Object({
+  access_token: t.String({ description: "JWT access token (short-lived)" }),
+  refresh_token: t.String({ description: "Refresh token (long-lived, store securely)" }),
+  expires_in: t.Number({ description: "Seconds until the access token expires" }),
+  token_type: t.String(),
+  user: t.Object({
+    id: t.String({ description: "User UUID" }),
+    email: t.Optional(t.String()),
+    created_at: t.String(),
+  }),
+});
+
+const ConfirmationSchema = t.Object({
+  message: t.String(),
+  code: t.Literal("EMAIL_CONFIRMATION_REQUIRED"),
+});
+
+const UserSchema = t.Object({
+  id: t.String({ description: "User UUID" }),
+  email: t.Optional(t.String()),
+  created_at: t.String(),
+});
+
+export function authRoutes() {
+  return (
+    new Elysia()
+      // ── POST /auth/register ───────────────────────────────────────────────
+      .post(
+        "/auth/register",
+        async ({ body, set }) => {
+          if (!authClient) {
+            set.status = 503;
+            return { error: "Auth service unavailable", code: "SERVICE_UNAVAILABLE" };
+          }
+          const { data, error } = await authClient.auth.signUp({
+            email: body.email,
+            password: body.password,
+          });
+          if (error) {
+            set.status = error.status ?? 400;
+            return { error: error.message, code: error.code ?? "AUTH_ERROR" };
+          }
+          if (!data.session) {
+            set.status = 202;
+            return {
+              message: "Check your email to confirm your account before signing in.",
+              code: "EMAIL_CONFIRMATION_REQUIRED" as const,
+            };
+          }
+          return {
+            access_token: data.session.access_token,
+            refresh_token: data.session.refresh_token,
+            expires_in: data.session.expires_in,
+            token_type: data.session.token_type,
+            user: {
+              id: data.user!.id,
+              email: data.user?.email,
+              created_at: data.user!.created_at,
+            },
+          };
+        },
+        {
+          body: t.Object({
+            email: t.String({ description: "User email address" }),
+            password: t.String({ minLength: 8, description: "Password (min 8 characters)" }),
+          }),
+          response: {
+            200: SessionSchema,
+            202: ConfirmationSchema,
+            400: ErrorSchema,
+            503: ErrorSchema,
+          },
+          detail: {
+            tags: ["Auth"],
+            summary: "Register",
+            description:
+              "Creates a new user account. Returns a session immediately if email confirmation " +
+              "is disabled, or a 202 with a confirmation prompt if email confirmation is enabled.",
+          },
+        },
+      )
+
+      // ── POST /auth/login ──────────────────────────────────────────────────
+      .post(
+        "/auth/login",
+        async ({ body, set }) => {
+          if (!authClient) {
+            set.status = 503;
+            return { error: "Auth service unavailable", code: "SERVICE_UNAVAILABLE" };
+          }
+          const { data, error } = await authClient.auth.signInWithPassword({
+            email: body.email,
+            password: body.password,
+          });
+          if (error) {
+            set.status = error.status ?? 400;
+            return { error: error.message, code: error.code ?? "AUTH_ERROR" };
+          }
+          return {
+            access_token: data.session.access_token,
+            refresh_token: data.session.refresh_token,
+            expires_in: data.session.expires_in,
+            token_type: data.session.token_type,
+            user: {
+              id: data.user.id,
+              email: data.user.email,
+              created_at: data.user.created_at,
+            },
+          };
+        },
+        {
+          body: t.Object({
+            email: t.String({ description: "User email address" }),
+            password: t.String({ description: "Account password" }),
+          }),
+          response: {
+            200: SessionSchema,
+            400: ErrorSchema,
+            401: ErrorSchema,
+            503: ErrorSchema,
+          },
+          detail: {
+            tags: ["Auth"],
+            summary: "Login",
+            description: "Authenticates with email and password. Returns an access token and refresh token.",
+          },
+        },
+      )
+
+      // ── POST /auth/refresh ────────────────────────────────────────────────
+      .post(
+        "/auth/refresh",
+        async ({ body, set }) => {
+          if (!authClient) {
+            set.status = 503;
+            return { error: "Auth service unavailable", code: "SERVICE_UNAVAILABLE" };
+          }
+          const { data, error } = await authClient.auth.refreshSession({
+            refresh_token: body.refresh_token,
+          });
+          if (error) {
+            set.status = error.status ?? 401;
+            return { error: error.message, code: error.code ?? "AUTH_ERROR" };
+          }
+          if (!data.session) {
+            set.status = 401;
+            return { error: "Invalid or expired refresh token", code: "INVALID_TOKEN" };
+          }
+          return {
+            access_token: data.session.access_token,
+            refresh_token: data.session.refresh_token,
+            expires_in: data.session.expires_in,
+            token_type: data.session.token_type,
+            user: {
+              id: data.user!.id,
+              email: data.user?.email,
+              created_at: data.user!.created_at,
+            },
+          };
+        },
+        {
+          body: t.Object({
+            refresh_token: t.String({ description: "Refresh token from a prior login or refresh" }),
+          }),
+          response: {
+            200: SessionSchema,
+            401: ErrorSchema,
+            503: ErrorSchema,
+          },
+          detail: {
+            tags: ["Auth"],
+            summary: "Refresh token",
+            description:
+              "Exchanges a refresh token for a new access token and refresh token pair. " +
+              "Refresh tokens are rotated on each use.",
+          },
+        },
+      )
+
+      // ── POST /auth/logout ─────────────────────────────────────────────────
+      .post(
+        "/auth/logout",
+        async ({ headers, set }) => {
+          const authHeader = headers.authorization;
+          if (!authHeader?.startsWith("Bearer ")) {
+            set.status = 401;
+            return { error: "Missing or invalid Authorization header", code: "MISSING_TOKEN" };
+          }
+          if (!authClient) {
+            set.status = 503;
+            return { error: "Auth service unavailable", code: "SERVICE_UNAVAILABLE" };
+          }
+          const accessToken = authHeader.slice(7);
+          const res = await fetch(`${supabaseUrl}/auth/v1/logout`, {
+            method: "POST",
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+              apikey: supabaseAnonKey,
+              "Content-Type": "application/json",
+            },
+          });
+          if (!res.ok) {
+            const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+            set.status = res.status;
+            return {
+              error: String(body.error_description ?? body.msg ?? "Logout failed"),
+              code: "LOGOUT_FAILED",
+            };
+          }
+          return { message: "Logged out successfully" };
+        },
+        {
+          response: {
+            200: t.Object({ message: t.String() }),
+            401: ErrorSchema,
+            503: ErrorSchema,
+          },
+          detail: {
+            tags: ["Auth"],
+            summary: "Logout",
+            description:
+              "Invalidates the current session. Requires a valid `Authorization: Bearer <access_token>` header. " +
+              "The refresh token is also revoked server-side.",
+          },
+        },
+      )
+
+      // ── Protected routes ──────────────────────────────────────────────────
+      // Routes below use authPlugin, which validates the Bearer token and
+      // injects `user` into the handler context. Public routes above are
+      // unaffected — the plugin scope does not propagate past this sub-app.
+      .use(
+        new Elysia()
+          .use(authPlugin)
+
+          // ── GET /auth/me ────────────────────────────────────────────────
+          .get(
+            "/auth/me",
+            ({ user }) => ({
+              id: user.id,
+              email: user.email ?? undefined,
+              created_at: user.created_at,
+            }),
+            {
+              response: {
+                200: UserSchema,
+                401: ErrorSchema,
+                503: ErrorSchema,
+              },
+              detail: {
+                tags: ["Auth"],
+                summary: "Get current user",
+                description:
+                  "Returns the authenticated user's profile. " +
+                  "Requires a valid `Authorization: Bearer <access_token>` header.",
+              },
+            },
+          ),
+      )
+  );
+}

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -59,7 +59,7 @@ export function authRoutes() {
             token_type: data.session.token_type,
             user: {
               id: data.user!.id,
-              email: data.user?.email,
+              email: data.user!.email,
               created_at: data.user!.created_at,
             },
           };
@@ -158,7 +158,7 @@ export function authRoutes() {
             token_type: data.session.token_type,
             user: {
               id: data.user!.id,
-              email: data.user?.email,
+              email: data.user!.email,
               created_at: data.user!.created_at,
             },
           };

--- a/packages/api/src/routes/decks.ts
+++ b/packages/api/src/routes/decks.ts
@@ -12,6 +12,8 @@ import {
   SimplifiedDeckResponseSchema,
   SimplifiedDeckSchema,
 } from "../schemas";
+import { authPlugin } from "../plugins/auth";
+import { optionalAuthPlugin } from "../plugins/optional-auth";
 
 /** Validate and parse an "id:qty" entry from the request body. */
 export function parseCardEntry(entry: string): { id: string; quantity: number } {
@@ -47,9 +49,14 @@ function simplifiedDeckToSchema(deck: SimplifiedDeck): any {
 
 export function decksRoutes(deckProvider: SimplifiedDeckProvider) {
   return new Elysia()
-    // ── GET /decks/u/:shortForm ───────────────────────────────────────────────
-    .get(
-      "/decks/u/:shortForm",
+    // ── Optional auth — visibility check will go here once deck model supports it
+    .use(
+      new Elysia()
+        .use(optionalAuthPlugin)
+
+        // ── GET /decks/u/:shortForm ─────────────────────────────────────────
+        .get(
+          "/decks/u/:shortForm",
       async ({ params, set }) => {
         try {
           const { deck, shortForm } = await deckProvider.getDeckFromShortForm(params.shortForm);
@@ -78,11 +85,17 @@ export function decksRoutes(deckProvider: SimplifiedDeckProvider) {
           description: "Decode a short form deck string back to full deck data.",
         },
       },
+        ),
     )
 
-    // ── POST /decks/u/:shortForm ──────────────────────────────────────────────
-    .post(
-      "/decks/u/:shortForm",
+    // ── Required auth — ownership checks will go here once deck model supports it
+    .use(
+      new Elysia()
+        .use(authPlugin)
+
+        // ── POST /decks/u/:shortForm ──────────────────────────────────────────
+        .post(
+          "/decks/u/:shortForm",
       async ({ body, params, set }) => {
         if (!body.cardsToAdd && !body.cardsToRemove) {
           set.status = 400;
@@ -130,11 +143,11 @@ export function decksRoutes(deckProvider: SimplifiedDeckProvider) {
             "Decode a short form deck string, replace the main deck cards with the provided ones, and return the updated short form and full deck data. Used for sharing decks with custom card lists.",
         },
       },
-    )
+        )
 
-    // ── POST /decks/u ─────────────────────────────────────────────────────────
-    .post(
-      "/decks/u",
+        // ── POST /decks/u ───────────────────────────────────────────────────
+        .post(
+          "/decks/u",
       async ({ body, set }) => {
         if (!body.cardsToAdd) {
           set.status = 400;
@@ -174,5 +187,6 @@ export function decksRoutes(deckProvider: SimplifiedDeckProvider) {
             "Create a new short form deck string from a provided list of card IDs and quantities. Used for sharing decks with custom card lists without needing an initial short form.",
         },
       },
+        ),
     );
 }

--- a/packages/api/wrangler.jsonc
+++ b/packages/api/wrangler.jsonc
@@ -12,6 +12,7 @@
     // Secrets — set once with:
     //   wrangler secret put SUPABASE_URL
     //   wrangler secret put SUPABASE_SERVICE_ROLE_KEY
+    //   wrangler secret put SUPABASE_ANON_KEY          ← required for auth routes
     //   wrangler secret put UPSTASH_REDIS_REST_URL
     //   wrangler secret put UPSTASH_REDIS_REST_TOKEN
     // Affiliate — set your Impact.com publisher ID to enable affiliate links:

--- a/packages/discord-bot/package.json
+++ b/packages/discord-bot/package.json
@@ -21,6 +21,6 @@
     "@riftseer/api": "workspace:*",
     "elysia": "^1.3.0",
     "typescript": "~5.8.0",
-    "wrangler": "^4.67.0"
+    "wrangler": "^4"
   }
 }

--- a/packages/frontend/src/components/PrivacyPage.tsx
+++ b/packages/frontend/src/components/PrivacyPage.tsx
@@ -16,7 +16,7 @@ export function PrivacyPage() {
         <Shield className="w-6 h-6 text-primary" />
         <h1 className="text-2xl font-bold">Privacy Policy</h1>
       </div>
-      <p className="text-sm text-muted-foreground mb-6">Last Updated: 5 April 2026</p>
+      <p className="text-sm text-muted-foreground mb-6">Last Updated: 9 May 2026</p>
 
       <p className="text-foreground leading-relaxed mb-8">
         This Privacy Policy describes how Riftseer collects, uses, and protects information when
@@ -45,7 +45,25 @@ export function PrivacyPage() {
           <ul className="space-y-3 text-foreground">
             <li>
               <strong>No account required.</strong> You can use the site and API without signing in.
-              We do not collect names, emails, or passwords.
+            </li>
+            <li>
+              <strong>Optional accounts.</strong> If you choose to register, we collect your{" "}
+              <strong>email address and password</strong> to create and authenticate your account.
+              Passwords are hashed and stored securely by{" "}
+              <a
+                href="https://supabase.com/privacy"
+                target="_blank"
+                rel="noreferrer"
+                className="text-primary hover:underline"
+              >
+                Supabase
+              </a>
+              {" "}(our authentication provider) — we never store plaintext passwords. Upon login,
+              Supabase issues a short-lived <strong>access token</strong> and a long-lived{" "}
+              <strong>refresh token</strong>; these are stored client-side and sent with authenticated
+              requests. You can revoke your session at any time via the logout endpoint
+              (<code className="bg-muted px-1 py-0.5 rounded text-xs">POST /api/v1/auth/logout</code>).
+              To delete your account, contact us through the project repository.
             </li>
             <li>
               <strong>Local storage (site only).</strong> The website stores one preference in your
@@ -169,6 +187,19 @@ export function PrivacyPage() {
               (e.g. IP, logs) as part of running the service.
             </li>
             <li>
+              <strong>Supabase (authentication).</strong> If you create an account, your email and
+              hashed password are stored and managed by Supabase. Supabase's own{" "}
+              <a
+                href="https://supabase.com/privacy"
+                target="_blank"
+                rel="noreferrer"
+                className="text-primary hover:underline"
+              >
+                privacy policy
+              </a>{" "}
+              applies to that data.
+            </li>
+            <li>
               <strong>PostHog.</strong> As described above, we use PostHog for site analytics.
               PostHog processes the analytics data according to their privacy policy.
             </li>
@@ -197,7 +228,9 @@ export function PrivacyPage() {
             data according to their policy and your settings. Stored Reddit comment/post IDs
             (used to prevent double-replies) are kept indefinitely so the bot continues to avoid
             duplicate replies. Logs of card requests by subreddit and Reddit username are retained
-            for as long as we use them for analytics and product improvement.
+            for as long as we use them for analytics and product improvement. Account data (email
+            and hashed password) is retained by Supabase for as long as your account exists; contact
+            us to request account deletion.
           </p>
         </section>
 
@@ -206,12 +239,13 @@ export function PrivacyPage() {
           <h2 className="text-lg font-semibold border-b border-border pb-2 mb-3">Your Rights</h2>
           <p className="text-foreground leading-relaxed mb-2">
             Depending on where you live, you may have rights to access, correct, or delete personal
-            data. Because we do not maintain user accounts, we have no login-based profile to
-            provide or delete. You can clear the theme preference by clearing local storage for
-            this site. PostHog may offer opt-out or privacy controls—see their privacy policy. For
-            Reddit-related data (including our logs of card requests by subreddit and username),
-            you can contact us to ask what we hold or to request deletion. Reddit’s own tools and
-            privacy policy also apply to your activity on Reddit.
+            data. If you have an account, you can contact us through the project repository to
+            request access to or deletion of your account data. You can clear the theme preference
+            by clearing local storage for this site. PostHog may offer opt-out or privacy
+            controls—see their privacy policy. For Reddit-related data (including our logs of card
+            requests by subreddit and username), you can contact us to ask what we hold or to
+            request deletion. Reddit’s own tools and privacy policy also apply to your activity on
+            Reddit.
           </p>
         </section>
 

--- a/packages/ingest-worker/package.json
+++ b/packages/ingest-worker/package.json
@@ -15,6 +15,6 @@
     "@cloudflare/workers-types": "^4.20260219.0",
     "@riftseer/types": "workspace:*",
     "typescript": "~5.8.0",
-    "wrangler": "^4.67.0"
+    "wrangler": "^4"
   }
 }

--- a/packages/web/.env.local.example
+++ b/packages/web/.env.local.example
@@ -1,0 +1,2 @@
+# Riftseer API base URL
+NEXT_PUBLIC_API_URL=https://api.riftseer.com


### PR DESCRIPTION
- Added authentication routes for user registration, login, refresh, and logout under `/api/v1/auth`.
- Integrated Supabase for session management, utilizing `@supabase/supabase-js` for handling user sessions.
- Updated documentation to include new auth endpoints and required environment variables.
- Enhanced existing routes to support optional and required authentication checks.
- Introduced plugins for managing authentication state and user sessions in the API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full auth flow added: register, login, refresh, logout and protected profile; bearer-token auth enforced with optional-auth for public endpoints.

* **Documentation**
  * New auth docs and expanded API docs with examples, endpoint details and env/secret guidance; privacy policy updated.

* **Chores**
  * Added SUPABASE_ANON_KEY example and runtime dependency on @supabase/supabase-js; .gitignore updated; CI workflows specify package manager and explicit Wrangler config; API spec generation tags updated.

* **Tests**
  * Tests updated to mock auth and include Authorization headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->