### PR TITLE
chore: standardize wrangler configs across all workers

### DIFF
--- a/.cursor/rules/api.mdc
+++ b/.cursor/rules/api.mdc
@@ -36,7 +36,7 @@ const data = await res.json()
 ## New Routes Checklist
 1. Add handler in `src/index.ts` with Elysia schema
 2. Add test in `src/__tests__/routes.test.ts`
-3. If the route exposes or logs new user/request data, update `packages/frontend/src/components/PrivacyPage.tsx`
+3. If the route exposes or logs new user/request data, update `packages/web/src/views/privacy-view.tsx`
 
 ## Provider Access
 - The provider is initialized once at startup via `createProvider()` from `@riftseer/core`

--- a/.cursor/rules/discord-bot.mdc
+++ b/.cursor/rules/discord-bot.mdc
@@ -59,4 +59,4 @@ bun run register  # Re-register commands after changes to src/commands.ts
 ```
 
 ## Privacy
-The bot does not persist data. If any logging or storage is added, update `packages/frontend/src/components/PrivacyPage.tsx`.
+The bot does not persist data. If any logging or storage is added, update `packages/web/src/views/privacy-view.tsx`.

--- a/.cursor/rules/frontend.mdc
+++ b/.cursor/rules/frontend.mdc
@@ -23,7 +23,7 @@ alwaysApply: false
 
 ## Routing
 - Routes are defined in `src/App.tsx` using React Router 7
-- Legal page routes are `/docs/terms` and `/docs/privacy` — do not change these paths without updating the footer links
+- `/docs/terms` and `/docs/privacy` are stubs linking to canonical legal pages on `packages/web` (`/terms`, `/privacy`); do not restore full legal copy here
 
 ## Theme
 - `useTheme()` from `src/hooks/useTheme.tsx` provides `{ theme, setTheme }`
@@ -31,21 +31,21 @@ alwaysApply: false
 - The `<html>` element gets a `dark` class; Tailwind uses `darkMode: 'class'`
 
 ## Legal Pages — MUST KEEP ACCURATE
-`PrivacyPage.tsx` and `TermsPage.tsx` are user-facing legal documents, not just UI components.
+Authoritative **Privacy Policy** is `packages/web/src/views/privacy-view.tsx`; **Terms of Service** is `packages/web/src/views/terms-view.tsx`.
 
-### Update PrivacyPage.tsx when:
-- A new analytics, monitoring, or tracking service is added or removed
-- New data is written to `localStorage`, cookies, or the server database
+### Update packages/web `privacy-view.tsx` when (not `PrivacyPage.tsx` stub):
+- A new analytics, monitoring, tracking, or consent service is added or removed
+- New data is written to `localStorage`, cookies, or the server database (site-wide)
 - The bot starts storing new KV keys or logging additional user data
 - A new third-party service (hosting, CDN, auth, error tracking) is introduced
 - Server log retention or content changes
 - PostHog configuration changes (session recording, sampling, opt-out mechanics)
 
-### Update TermsPage.tsx when:
+### Update packages/web `terms-view.tsx` when (not `TermsPage.tsx` stub):
 - Acceptable-use rules change (new prohibited actions)
 - Age requirements change
 - Riot Games / Riftbound trademark or attribution language needs updating
 - Liability, warranty, or dispute resolution wording changes
 - Contact information changes
 
-**Always update the "Last Updated" date at the top of the component when modifying either legal page.**
+**Always update the "Last updated" date** in the respective `packages/web` view when you change that document.

--- a/.cursor/rules/project.mdc
+++ b/.cursor/rules/project.mdc
@@ -41,4 +41,4 @@ All runtime config comes from env vars. Document any new variable in `.env.examp
 - Don't add comments to self-evident code
 
 ## Legal Pages
-`packages/frontend/src/components/PrivacyPage.tsx` and `TermsPage.tsx` are user-facing legal documents. If you add new data collection, new third-party services, or change how data is stored/retained, you **must** update the relevant legal page and its "Last Updated" date.
+`packages/web/src/views/privacy-view.tsx` and `packages/web/src/views/terms-view.tsx` are the Privacy Policy and Terms of Service. If you add new data collection, new third-party services, or change how data is stored/retained, you **must** update the relevant legal document and its date line ("Last updated"). If acceptable use, liability, or trademark language changes, update `terms-view.tsx`.

--- a/.cursor/rules/reddit-bot.mdc
+++ b/.cursor/rules/reddit-bot.mdc
@@ -69,7 +69,7 @@ post.authorId           // string ID — NOT the username
 - Do NOT remove this override
 
 ## Privacy
-If the bot begins storing new KV keys or logging additional fields (user IDs, subreddit names, card text, etc.), update `packages/frontend/src/components/PrivacyPage.tsx` to reflect what is collected, why, and for how long.
+If the bot begins storing new KV keys or logging additional fields (user IDs, subreddit names, card text, etc.), update `packages/web/src/views/privacy-view.tsx` to reflect what is collected, why, and for how long.
 
 Current bot data footprint:
 - **KV store**: Only replied comment/post IDs (deduplication)

--- a/packages/api/CLAUDE.md
+++ b/packages/api/CLAUDE.md
@@ -63,7 +63,7 @@ const json = await res.json()
 2. Add Elysia schema annotations (`.query()`, `.body()`, `.response()`) for Eden Treaty types
 3. Write a test in `src/__tests__/routes.test.ts`
 4. Update or add the relevant doc page in `packages/api/docs/`
-5. If the route exposes new personal data or logs new information, update `PrivacyPage.tsx`
+5. If the route exposes new personal data or logs new information, update `packages/web/src/views/privacy-view.tsx`
 
 ## Error Handling
 - Return `{ error: string }` with appropriate HTTP status codes

--- a/packages/api/wrangler.jsonc
+++ b/packages/api/wrangler.jsonc
@@ -1,22 +1,20 @@
 {
-  "name": "riftseer-api",
-  "main": "src/index.ts",
-  "compatibility_date": "2025-06-01",
-  "workers_dev": true,
-  "preview_urls": false,
-  "dev": { "port": 8789 },
-  "compatibility_flags": ["nodejs_compat"],
-  "observability": { "enabled": true },
-  "vars": {
-    "CARD_PROVIDER": "supabase"
-    // Secrets — set once with:
-    //   wrangler secret put SUPABASE_URL
-    //   wrangler secret put SUPABASE_SERVICE_ROLE_KEY
-    //   wrangler secret put SUPABASE_ANON_KEY          ← required for auth routes
-    //   wrangler secret put UPSTASH_REDIS_REST_URL
-    //   wrangler secret put UPSTASH_REDIS_REST_TOKEN
-    // Affiliate — set your Impact.com publisher ID to enable affiliate links:
-    //   wrangler secret put TCGPLAYER_AFFILIATE_ID
-    //   (deep link format: https://partner.tcgplayer.com/c/{id}/1780961/21018?u={productUrl})
-  }
+	"$schema": "node_modules/wrangler/config-schema.json",
+	"name": "riftseer-api",
+	"main": "src/index.ts",
+	"compatibility_date": "2025-06-01",
+	"workers_dev": false,
+	"preview_urls": false,
+	"dev": { "port": 8789 },
+	"compatibility_flags": ["nodejs_compat"],
+	"observability": { "enabled": true },
+	"vars": {
+		"CARD_PROVIDER": "supabase"
+	},
+	// Required for core API + Supabase auth routes.
+	// Optional secrets (omit from required): UPSTASH_REDIS_REST_URL, UPSTASH_REDIS_REST_TOKEN, TCGPLAYER_AFFILIATE_ID
+	// https://developers.cloudflare.com/workers/wrangler/configuration/#secrets-configuration-property
+	"secrets": {
+		"required": ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY", "SUPABASE_ANON_KEY"]
+	}
 }

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -36,7 +36,7 @@ Tests live in `src/__tests__/`. Use `mock()` from `bun:test` for provider mocks.
 If a new field is added to the canonical `Card` type:
 - Update `packages/types/src/card.ts` (source of truth) and `packages/ingest-worker/src/riftcodex.ts` (rawToCard) and Supabase provider row mapping
 - Update the card object field table in `packages/api/docs/cards.md`
-- Check whether `PrivacyPage.tsx` mentions the data — update if the field affects what is collected or stored
+- Check whether `packages/web/src/views/privacy-view.tsx` mentions the data — update if the field affects what is collected or stored
 
 ## Documentation
 Doc pages for this package live in `packages/core/docs/`. Keep them up to date when making changes — if behaviour, types, or the provider interface changes, update the relevant doc page alongside the code.

--- a/packages/discord-bot/CLAUDE.md
+++ b/packages/discord-bot/CLAUDE.md
@@ -74,7 +74,7 @@ Run `bun run register` from `packages/discord-bot` (needs `DISCORD_BOT_TOKEN` an
 - Type-only imports from `@riftseer/api` and `elysia` are stripped at bundle time
 
 ## Privacy
-The Discord bot does not store any data. It forwards the card name to the Riftseer API and returns the result. If logging or persistence is added, update `packages/frontend/src/components/PrivacyPage.tsx`.
+The Discord bot does not store any data. It forwards the card name to the Riftseer API and returns the result. If logging or persistence is added, update `packages/web/src/views/privacy-view.tsx`.
 
 ## Documentation
 Doc pages for this bot live in `packages/discord-bot/docs/discord-bot.md`. The dev docs site copies this file into `docs/doc-pages/clients-bots/` when you run `bun run build` or `bun run start` in `docs/` (see `sync-clients-bots-docs`). Keep the doc up to date when slash commands, interaction flow, or secrets change.

--- a/packages/discord-bot/wrangler.jsonc
+++ b/packages/discord-bot/wrangler.jsonc
@@ -1,20 +1,22 @@
 {
-  "name": "riftseer-discord-bot",
-  "main": "src/index.ts",
-  "compatibility_date": "2025-01-01",
-  "services": [
-    {
-      "binding": "RIFTSEER_API",
-      "service": "riftseer-api"
-    }
-  ],
-  // Production vars. Override at deploy with --var API_BASE_URL:... --var SITE_BASE_URL:... if needed.
-  "vars": {
-    "API_BASE_URL": "https://riftseer-api.thinkhuman-21f.workers.dev",
-    "SITE_BASE_URL": "https://riftseer.com"
-  }
-  // Secrets — set once with:
-  //   wrangler secret put DISCORD_PUBLIC_KEY
-  //   wrangler secret put DISCORD_BOT_TOKEN
-  //   wrangler secret put DISCORD_APPLICATION_ID
+	"$schema": "node_modules/wrangler/config-schema.json",
+	"name": "riftseer-discord-bot",
+	"main": "src/index.ts",
+	"compatibility_date": "2025-01-01",
+	"workers_dev": false,
+	"preview_urls": false,
+	"services": [
+		{
+			"binding": "RIFTSEER_API",
+			"service": "riftseer-api"
+		}
+	],
+	"vars": {
+		"API_BASE_URL": "https://api.riftseer.com",
+		"SITE_BASE_URL": "https://riftseer.com"
+	},
+	// https://developers.cloudflare.com/workers/wrangler/configuration/#secrets-configuration-property
+	"secrets": {
+		"required": ["DISCORD_PUBLIC_KEY", "DISCORD_BOT_TOKEN", "DISCORD_APPLICATION_ID"]
+	}
 }

--- a/packages/frontend/wrangler.jsonc
+++ b/packages/frontend/wrangler.jsonc
@@ -1,11 +1,15 @@
+/**
+ * Static SPA (Vite build → ./dist). API origin is compile-time: set VITE_API_URL when running `vite build`
+ * (CI / local), not Worker vars — this Worker only serves assets.
+ */
 {
-  "$schema": "node_modules/wrangler/config-schema.json",
-  "name": "riftseer-frontend",
-  "compatibility_date": "2026-02-19",
-  "assets": {
-    "directory": "./dist",
-    "not_found_handling": "single-page-application"
-  }
-  // Secrets — set once with:
-  //   npx wrangler pages secret put VITE_API_URL --project-name riftseer-frontend
+	"$schema": "node_modules/wrangler/config-schema.json",
+	"name": "riftseer-frontend",
+	"compatibility_date": "2026-02-19",
+	"workers_dev": false,
+	"preview_urls": false,
+	"assets": {
+		"directory": "./dist",
+		"not_found_handling": "single-page-application"
+	}
 }

--- a/packages/ingest-worker/wrangler.toml
+++ b/packages/ingest-worker/wrangler.toml
@@ -1,15 +1,21 @@
 # Riftseer ingest worker — runs full ingestion pipeline on a schedule (no Elysia API).
-# Set secrets: wrangler secret put SUPABASE_URL, wrangler secret put SUPABASE_SERVICE_ROLE_KEY
-# Optional: RIFTCODEX_BASE_URL, RIFTCODEX_API_KEY in vars or secrets.
+# Required secrets: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY ([secrets.required] below).
+# Optional: wrangler secret put RIFTCODEX_API_KEY, INGEST_SECRET (manual POST /ingest auth).
 
 name = "riftseer-ingest"
 main = "src/index.ts"
 compatibility_date = "2025-01-01"
+workers_dev = false
+preview_urls = false
 
 # Scheduled events: run every 6 hours (see Miniflare /cdn-cgi/mf/scheduled for local testing)
 [triggers]
 crons = ["0 */6 * * *"]
 
-# Optional vars (override in dashboard or wrangler deploy --var)
+# Plain vars (override via dashboard or wrangler deploy --var)
 [vars]
 RIFTCODEX_BASE_URL = "https://api.riftcodex.com"
+
+# https://developers.cloudflare.com/workers/wrangler/configuration/#secrets-configuration-property
+[secrets]
+required = [ "SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY" ]

--- a/packages/raycast-extension/CLAUDE.md
+++ b/packages/raycast-extension/CLAUDE.md
@@ -56,7 +56,7 @@ Card types (`Card`, `RelatedCard`, etc.) are imported directly from `@riftseer/t
 Do not upgrade `@types/react` without checking `@raycast/api`'s peer deps first — version mismatches cause widespread JSX type errors.
 
 ## Privacy
-This extension makes read-only HTTP requests to the Riftseer API. It stores a bounded list of recently viewed card payloads in Raycast local storage (for the Search Cards empty state and history cap); that data stays on the device and is not sent to Riftseer. No analytics or tracking. If this ever changes, update `packages/frontend/src/components/PrivacyPage.tsx`.
+This extension makes read-only HTTP requests to the Riftseer API. It stores a bounded list of recently viewed card payloads in Raycast local storage (for the Search Cards empty state and history cap); that data stays on the device and is not sent to Riftseer. No analytics or tracking. If this ever changes, update `packages/web/src/views/privacy-view.tsx`.
 
 ## Documentation
 Doc pages for this extension live in `packages/raycast-extension/docs/raycast-extension.md`. The dev docs site copies this file into `docs/doc-pages/clients-bots/` when you run `bun run build` or `bun run start` in `docs/` (see `sync-clients-bots-docs`). Keep the doc up to date when commands, preferences, or the API call change.

--- a/packages/reddit-bot/CLAUDE.md
+++ b/packages/reddit-bot/CLAUDE.md
@@ -81,7 +81,7 @@ Replied comment/post IDs are stored in the KV store to prevent duplicate replies
 `tsconfig.json` overrides `"types": []` to suppress a vitest/globals conflict that Devvit's base tsconfig introduces. Do not remove this override.
 
 ## Privacy Implications
-If the bot begins storing new data in the KV store or logging additional fields (e.g., user IDs, subreddit names, card request text), update `PrivacyPage.tsx` in `packages/frontend` to reflect what is collected, why, and how long it is retained.
+If the bot begins storing new data in the KV store or logging additional fields (e.g., user IDs, subreddit names, card request text), update `packages/web/src/views/privacy-view.tsx` to reflect what is collected, why, and how long it is retained.
 
 The current data stored:
 - **KV store**: Replied comment/post IDs only (for deduplication)

--- a/packages/types/CLAUDE.md
+++ b/packages/types/CLAUDE.md
@@ -39,7 +39,7 @@ If a new field is added to the canonical `Card` type:
 - Update `packages/ingest-worker/src/riftcodex.ts` (`rawToCard`)
 - Update the row mapping in `packages/core/src/providers/supabase.ts` (`dbRowToCard`)
 - Update the field table in `packages/api/docs/cards.md`
-- Check `PrivacyPage.tsx` if the field affects what data is stored or shown
+- Check `packages/web/src/views/privacy-view.tsx` if the field affects what data is stored or shown
 
 ## Documentation
 Doc pages live in `packages/types/docs/`. Keep them up to date when making changes to types, parser behaviour, or the icon map.

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,8 +1,14 @@
+/**
+ * Deploy from repo root (paths relative to this file). Prefer `packages/frontend/wrangler.jsonc` when cwd is packages/frontend.
+ */
 {
-  "name": "riftseer-frontend",
-  "compatibility_date": "2026-02-19",
-  "assets": {
-    "directory": "packages/frontend/dist",
-    "not_found_handling": "single-page-application"
-  }
+	"$schema": "node_modules/wrangler/config-schema.json",
+	"name": "riftseer-frontend",
+	"compatibility_date": "2026-02-19",
+	"workers_dev": false,
+	"preview_urls": false,
+	"assets": {
+		"directory": "packages/frontend/dist",
+		"not_found_handling": "single-page-application"
+	}
 }


### PR DESCRIPTION
Add $schema, workers_dev/preview_urls: false, and secrets.required declarations to all Cloudflare Worker configs so wrangler fails fast on missing secrets and never auto-publishes on *.workers.dev.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal guidance across multiple packages to reference consolidated privacy documentation location.
  * Enhanced Wrangler configuration documentation with deployment and schema guidance.

* **Chores**
  * Updated API and worker configuration settings for deployment and environment management.
  * Disabled development URLs in Cloudflare Workers configurations.
  * Added formal secret requirement declarations in worker configurations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EggsLeggs/Riftseer/pull/64)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->