### PR TITLE
feat(web): user profiles, settings, and Metafy integration

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,2 @@
+[mcp_servers.metafy-api]
+url = "https://dev.metafy.gg/mcp"

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,14 @@
+# ─── Metafy OAuth (packages/api — Metafy developer app) ───────────────────────
+# Create app at https://metafy.gg/account/settings/developers
+# Authorization URL: https://metafy.gg/auth/authorize  Token: https://metafy.gg/irk/oauth/token
+# Non-secret vars also in packages/api/wrangler.jsonc → vars. Secret via wrangler secret put.
+METAFY_CLIENT_ID=
+METAFY_CLIENT_SECRET=
+METAFY_COMMUNITY_ID=
+METAFY_REDIRECT_URI=http://localhost:3000/auth/metafy/callback
+# Webhook secret — only available to Metafy Partners. Set in Metafy account settings.
+METAFY_WEBHOOK_SECRET=
+
 # ─── API ───────────────────────────────────────────────────────────────────────
 CARD_PROVIDER=supabase
 API_PORT=3000

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,205 @@
+# Riftseer — Project Context for Codex
+
+## Overview
+Riftseer is a Riftbound TCG card data platform. It exposes a REST API, a Next.js frontend, a Discord bot, and a Reddit bot that all share a common card data model.
+
+## Monorepo Structure
+
+```text
+riftseer/
+├── packages/types/          # Zero-dependency types, parser, icon tokens (@riftseer/types)
+├── packages/core/           # Provider interface, Supabase provider, search, deck model (@riftseer/core)
+├── packages/api/            # ElysiaJS REST API — Cloudflare Worker (wrangler dev/deploy)
+├── packages/web/            # Next.js App Router SPA — Cloudflare Workers via OpenNext (@riftseer/web)
+├── packages/frontend/       # React 19 + Vite SPA — DEPRECATED, to be removed (replaced by packages/web)
+├── packages/discord-bot/    # Discord bot on Cloudflare Workers (Bun workspace member)
+├── packages/ingest-worker/  # Cloudflare Worker — scheduled ingest (RiftCodex → Supabase, no API)
+└── packages/reddit-bot/     # Devvit Reddit bot (NOT a Bun workspace member)
+```
+
+`packages/reddit-bot` is a standalone npm project excluded from the root Bun workspace (managed separately). Workspace members are `packages/types`, `packages/core`, `packages/api`, `packages/web`, `packages/discord-bot`, and `packages/ingest-worker`. (`packages/frontend` remains in the tree as deprecated Vite SPA; prefer `packages/web`.)
+
+## Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Runtime | Bun ≥ 1.2 (workspace tooling) + Cloudflare Workers (API runtime) |
+| API | ElysiaJS 1.4+ with CloudflareAdapter + @elysiajs/cors |
+| DB | bun:sqlite (built-in, no extra dep) |
+| Web (packages/web) | Next.js App Router, Tailwind CSS 4, Cloudflare Workers via OpenNext |
+| Frontend (deprecated) | React 19, React Router 7, Tailwind CSS 4, Vite 6 — replaced by packages/web |
+| Card name search | Postgres `tsvector` full-text search (Supabase) |
+| API client | @elysiajs/eden (type-safe, Eden Treaty) |
+| Testing | bun test (Jest-compatible) |
+| Discord bot | Cloudflare Workers + discord-api-types |
+| Reddit bot | Devvit (Reddit platform) |
+
+## Running the Project
+```bash
+bun dev             # API (wrangler dev) + frontend together
+bun dev:api         # API only via wrangler dev (http://localhost:8789)
+bun dev:web         # packages/web Next.js dev server
+bun build:web       # packages/web production build
+bun dev:frontend    # packages/frontend (deprecated)
+bun test            # Run all tests
+bun typecheck       # Type-check all workspace packages
+
+# Discord bot (workspace member, Cloudflare Workers)
+cd packages/discord-bot
+bun run dev         # wrangler dev (local)
+bun run deploy      # wrangler deploy (production)
+bun run register    # Register slash commands with Discord (run once after changes)
+
+# Ingest worker (workspace member, Cloudflare Workers — scheduled events)
+cd packages/ingest-worker
+bun run dev         # wrangler dev; requires packages/ingest-worker/.dev.vars with SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY
+# Trigger ingest locally (while wrangler dev is running):
+curl "http://localhost:8787/cdn-cgi/mf/scheduled"                              # scheduled event trigger
+curl -X POST "http://localhost:8787/ingest"                                    # HTTP POST (no INGEST_SECRET set)
+curl -X POST -H "Authorization: Bearer <INGEST_SECRET>" "http://localhost:8787/ingest"  # with INGEST_SECRET
+bun run deploy      # wrangler deploy (set SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY via wrangler secret put)
+
+# Reddit bot (separate standalone project)
+cd packages/reddit-bot
+npx devvit upload   # Deploy to Reddit
+npx devvit settings set apiBaseUrl   # Set per-install config
+npx devvit settings set siteBaseUrl
+```
+
+## Environment Variables
+
+### API Worker (packages/api — set via `wrangler secret put` or `wrangler.jsonc` vars)
+| Variable | Purpose |
+|----------|---------|
+| `CARD_PROVIDER` | `supabase` (only; data from ingest pipeline) — set in `wrangler.jsonc` vars |
+| `SUPABASE_URL` | Supabase project URL — required |
+| `SUPABASE_SERVICE_ROLE_KEY` | Supabase service-role JWT — required |
+| `SUPABASE_ANON_KEY` | Supabase anon/public JWT — required for `/api/v1/auth/*`. Use root `.env` / `.env.example` for local reference; for the deployed API Worker set via `cd packages/api && wrangler secret put SUPABASE_ANON_KEY` (see `secrets.required` in `packages/api/wrangler.jsonc`). |
+| `UPSTASH_REDIS_REST_URL` | Upstash Redis REST URL — optional |
+| `UPSTASH_REDIS_REST_TOKEN` | Upstash Redis REST token — required when `UPSTASH_REDIS_REST_URL` is set |
+| `CACHE_REFRESH_INTERVAL_MS` | Provider stats refresh interval in ms (default 6h) |
+| `LEGAL_TERMS_VERSION` | Version string stored with new users’ Terms acceptance at registration (`POST /auth/register`). **Set in `packages/api/wrangler.jsonc` → `vars`.** When you publish material Terms updates, bump this value and redeploy the API Worker so new signups record the new version. (Code still defaults to `1` if the binding is missing.) |
+| `LEGAL_PRIVACY_VERSION` | Same for Privacy Policy acceptance. **Set in `packages/api/wrangler.jsonc` → `vars`** — bump alongside material Privacy policy updates and redeploy. |
+| `SITE_ORIGIN` | Public site origin (no trailing slash) used to build absolute `riftseer_uri` values on every card response. **Set in `packages/api/wrangler.jsonc` → `vars`.** When unset, `riftseer_uri` is omitted and clients fall back to the legacy `/card/<id>` path. |
+
+### Ingest Worker (packages/ingest-worker)
+| Variable | Purpose |
+|----------|---------|
+| `SUPABASE_URL` | Supabase project URL — required |
+| `SUPABASE_SERVICE_ROLE_KEY` | Supabase service-role JWT — required |
+| `RIFTCODEX_BASE_URL` | RiftCodex API base (default: `https://api.riftcodex.com`) — optional |
+| `RIFTCODEX_API_KEY` | RiftCodex API key — optional |
+| `UPSTREAM_TIMEOUT_MS` | Timeout for upstream HTTP requests in ms (default: 30000) — optional |
+| `INGEST_SECRET` | Bearer token for POST /ingest (optional) |
+
+### Web (packages/web)
+Production plain vars live under `env.production.vars` in `packages/web/wrangler.jsonc` (deploy with `opennextjs-cloudflare deploy --env production`). Mirror them in `.env.example` / local `.env` — they must match the values passed at build time (`opennextjs-cloudflare build`) and in `.github/workflows/web.yml`.
+
+| Variable | Purpose |
+|----------|---------|
+| `NEXT_PUBLIC_API_URL` | Public API base URL used by the web client (e.g. `http://localhost:8789` locally, `https://api.riftseer.com` in production) |
+| `NEXT_PUBLIC_APP_URL` | Public site/app URL used for OAuth/email `redirect_to` URLs (e.g. `http://localhost:3000` locally, `https://riftseer.com` in production) |
+| `C15T_DATABASE_URL` | Supabase transaction pooler connection string — use port 6543 and append `?prepare=false`. Example value format: `postgresql://postgres.<project-ref>:<password>@aws-0-<region>.pooler.supabase.com:6543/postgres?prepare=false`. Required for the c15t consent backend. Declared under `secrets.required` in `packages/web/wrangler.jsonc`; set remotely via `cd packages/web && wrangler secret put C15T_DATABASE_URL`, and locally via `packages/web/.dev.vars`. |
+
+### GitHub Actions — ingest worker deploy (`.github/workflows/ingest-worker.yml`)
+
+| Secret | Purpose |
+|----------|---------|
+| `SUPABASE_DB_URL` | **Postgres** connection URI for `psql` only: confirms every file in `supabase/migrations/` is in `supabase_migrations.schema_migrations`. Prefer **Session** or **Transaction pooler** from **Dashboard → Database → Connection string** — GitHub Actions is usually **IPv4-only**, and Supabase’s **direct** host (`db.*.supabase.co:5432`) may not work without IPv4 support. Put your DB password in the URI. **Not** `https://*.supabase.co` and **not** `SUPABASE_SERVICE_ROLE_KEY`. |
+
+## Key Architecture Decisions
+- **Provider pattern**: `CardDataProvider` interface in `packages/core`; the only implementation is `SupabaseCardProvider` (data from the ingest pipeline).
+- **Bots delegate to API**: Both the Discord bot and Reddit bot call the external `/api/v1/cards/resolve` endpoint.
+- **Ingest**: Modular pipeline runs as a Cloudflare Worker on a schedule. No ingest endpoint in the API. See [Ingest Pipeline](#ingest-pipeline) below.
+- **Card name search**: Postgres `tsvector` on `name` + `name_normalized`. Exact `name_normalized` match is tried first; full-text search is used as fallback.
+- **Card IDs**: `cards.id` is `text` (MongoDB ObjectIds from RiftCodex — 24-char hex strings).
+- **Public card URLs**: Each printing has a stable `cards.public_slug` (e.g. `ogn/12a/signature/sun-disc`) generated on first ingest and **never overwritten** by subsequent runs — public URLs do not drift when upstream data is corrected. The API computes an absolute `riftseer_uri` on every card response (and on every related-card stub) using `SITE_ORIGIN`. Tools should prefer `card.riftseer_uri` over building URLs by id. Slug rules live in `packages/types/src/slug.ts`.
+
+## Ingest Pipeline
+
+The pipeline runs inside `packages/ingest-worker` and is orchestrated by `src/ingest.ts`:
+
+```text
+RiftCodex /sets + /cards
+    ↓ src/sources/riftcodex.ts  — fetch + map to Card[]
+    ↓ src/pipeline/normalize.ts — apply overrides, build IngestSet[]
+    ↓ src/pipeline/enrich.ts    — clearDuplicateImages (alt-art/reprints)
+    ↓ src/sources/tcgcsv.ts     — fetch TCGPlayer groups, products, prices
+    ↓ src/pipeline/enrich.ts    — reconcileSets + enrichCards (prices, purchase URIs, fallback images)
+    ↓ src/pipeline/link.ts      — linkTokens, linkChampionsLegends, linkRelatedPrintings
+    ↓ src/pipeline/db.ts        — ingestCardData() RPC → Supabase (atomic upsert)
+```
+
+**Key files:**
+
+| File | Purpose |
+|------|---------|
+| `src/index.ts` | CF Worker entry — `scheduled` handler + `POST /ingest` HTTP trigger |
+| `src/ingest.ts` | Pipeline coordinator (`runIngest`) + `Env` type |
+| `src/utils.ts` | Local `logger` + `normalizeCardName` (can't import @riftseer/core in CF Workers) |
+| `src/sources/riftcodex.ts` | Fetch RiftCodex `/sets` and `/cards`; `rawToCard` mapper |
+| `src/sources/tcgcsv.ts` | Fetch TCGPlayer groups, products, and prices via TCGCSV |
+| `src/pipeline/types.ts` | `IngestSet` — internal set type with external_ids |
+| `src/pipeline/normalize.ts` | `normalizeSets` / `normalizeCards` — apply overrides |
+| `src/pipeline/enrich.ts` | `reconcileSets`, `clearDuplicateImages`, `buildProductMap`, `enrichCards` |
+| `src/pipeline/link.ts` | `linkTokens`, `linkChampionsLegends`, `linkRelatedPrintings` |
+| `src/pipeline/db.ts` | `ingestCardData()` — calls `ingest_card_data` Postgres RPC |
+| `src/overrides/` | JSON override files for sets, TCGPlayer groups, individual cards |
+
+**Overrides** (`src/overrides/*.json`) allow correcting or augmenting upstream data without code changes:
+- `riftcodex_sets.json` — override set names, `is_promo`, `parent_set_code`
+- `tcgplayer_groups.json` — map TCGPlayer groupId → canonical set_code / name / parent
+- `cards.json` — per-card overrides (e.g. `use_tcgplayer_image: true`)
+
+**TCGPlayer enrichment is non-fatal**: if TCGCSV is unavailable, the pipeline continues without prices/images. Cards still get upserted with RiftCodex data only.
+
+**Supabase RPC**: All three tables (sets, artists, cards) are written atomically via `ingest_card_data(p_sets, p_artists, p_cards)`. The current definition lives in `supabase/migrations/20260510030000_add_cards_public_slug.sql` (extends the earlier `20260407160000_fix_ingest_rpc_id_cast.sql` with the `public_slug` column). The `ON CONFLICT` clause `coalesce`s on `public_slug` so URLs are stable across ingest runs but still backfilled when null.
+
+## Deployment
+- **API**: Cloudflare Workers via `cd packages/api && wrangler deploy`. Secrets set with `wrangler secret put`. Worker name: `riftseer-api`.
+- **Web (packages/web)**: Cloudflare Workers via `@opennextjs/cloudflare`. Run `bun run deploy` from `packages/web`. Build-time env vars must be set in the Workers Builds dashboard.
+- **Frontend (deprecated)**: Cloudflare Pages (separate deployment) — will be removed when packages/web is complete.
+- **Discord bot**: Cloudflare Workers via `wrangler deploy`. Secrets set with `wrangler secret put`.
+- **Reddit bot**: Devvit upload (`npx devvit upload`). The bot's HTTP fetch domain must be registered in `devvit.yaml`.
+
+## Database Migrations (Supabase)
+Migrations live in `supabase/migrations/`. Apply them in one of three ways:
+
+```bash
+# 1. Supabase CLI (recommended — install from https://supabase.com/docs/guides/cli)
+supabase login
+supabase db push          # pushes all pending migrations to the linked project
+
+# 2. Supabase dashboard SQL editor
+#    Open https://supabase.com/dashboard → your project → SQL Editor,
+#    paste the contents of each migration file and run.
+
+# 3. psql (direct Postgres connection string)
+psql "$SUPABASE_DB_URL" -f supabase/migrations/20260221000000_initial_schema.sql
+```
+
+When adding a new migration, create a new file in `supabase/migrations/` with a
+timestamp prefix (`YYYYMMDDHHmmss_description.sql`) and never edit existing
+migration files.
+
+## RiftCodex API
+- Base URL: `https://api.riftcodex.com`
+- Pagination: `GET /cards?page=N&size=100` → `{ items: Card[], total, page, size, pages }`
+- ~656 cards across 14 pages (as of 2026-02)
+
+## Legal Pages — IMPORTANT
+Authoritative policy copy lives in **`packages/web/src/views/privacy-view.tsx`** (route `/privacy`) and **`packages/web/src/views/terms-view.tsx`** (route `/terms`). Shared layout primitives for both live in `packages/web/src/views/legal-document.tsx`.
+
+The deprecated SPA (`packages/frontend`) keeps `/docs/privacy` and `/docs/terms` as short stubs linking to the canonical URLs on the main site.
+
+When policy content changes, update **both** the relevant view component (`privacy-view.tsx` or `terms-view.tsx`) **and** its “Last updated” line; if routes or filenames change, update **this notice** too. For **material** changes that should distinguish new user consent, **bump `LEGAL_TERMS_VERSION` and/or `LEGAL_PRIVACY_VERSION` in `packages/api/wrangler.jsonc`** (`vars`) and redeploy the API Worker (`cd packages/api && wrangler deploy`).
+
+If any of the following change, **update the relevant legal page (and this notice if paths change)**:
+- Data collected (e.g., new analytics, new fields stored in KV or DB)
+- Third-party services added or removed (hosting, analytics, data providers)
+- Bot behaviour (new triggers, new data logged, new KV keys)
+- Scope of card data use or attribution
+- Age requirements or acceptable-use rules
+- Contact information or dispute resolution process
+
+See each package's own `AGENTS.md` for package-specific guidance.

--- a/bun.lock
+++ b/bun.lock
@@ -43,6 +43,7 @@
       "dependencies": {
         "@elysiajs/cors": "^1.4.1",
         "@riftseer/core": "workspace:*",
+        "@riftseer/types": "workspace:*",
         "@supabase/supabase-js": "^2.97.0",
         "elysia": "^1.4.7",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -156,6 +156,7 @@
         "react-dom": "19.2.4",
         "react-hook-form": "^7.56.0",
         "shadcn": "^4.7.0",
+        "simple-icons": "^16.19.0",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
         "zod": "^4.4.3",
@@ -3589,6 +3590,8 @@
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "simple-icons": ["simple-icons@16.19.0", "", {}, "sha512-muxcz/FDvWFPrKJdsjaz79qsBjtZeVKUVIFl7wLVOwb+yqAag8FPe8+hFlMVRnmAXYQIm4eUDDm2+dhOj0cFgQ=="],
 
     "sirv": ["sirv@2.0.4", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ=="],
 

--- a/packages/api/.dev.vars.example
+++ b/packages/api/.dev.vars.example
@@ -12,3 +12,13 @@ UPSTASH_REDIS_REST_TOKEN=
 
 # Optional — set to your Impact.com publisher ID to enable TCGPlayer affiliate links
 TCGPLAYER_AFFILIATE_ID=
+
+# Metafy OAuth — https://metafy.gg/account/settings/developers
+# Authorization URL: https://metafy.gg/auth/authorize
+# Token URL: https://metafy.gg/irk/oauth/token
+METAFY_CLIENT_ID=
+METAFY_CLIENT_SECRET=
+METAFY_COMMUNITY_ID=
+METAFY_REDIRECT_URI=http://localhost:3000/auth/metafy/callback
+# Optional — only available to Metafy Partners (set in Metafy account settings)
+METAFY_WEBHOOK_SECRET=

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@elysiajs/cors": "^1.4.1",
     "@riftseer/core": "workspace:*",
+    "@riftseer/types": "workspace:*",
     "@supabase/supabase-js": "^2.97.0",
     "elysia": "^1.4.7"
   },

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -101,7 +101,7 @@ export const app = new Elysia({ adapter: CloudflareAdapter })
   .use(
     cors({
       origin: true, // Reflect any Origin — public API, browser requests from any site are allowed
-      methods: ["GET", "HEAD", "POST", "DELETE", "OPTIONS"],
+      methods: ["GET", "HEAD", "POST", "PATCH", "DELETE", "OPTIONS"],
     }),
   )
   .use(

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -42,6 +42,7 @@ import { cardsRoutes } from "./routes/cards";
 import { setsRoutes } from "./routes/sets";
 import { decksRoutes } from "./routes/decks";
 import { authRoutes } from "./routes/auth";
+import { usersRoutes } from "./routes/users";
 
 // ─── Singletons ───────────────────────────────────────────────────────────────
 // CF Workers forbid async I/O (fetch) in global scope — only inside handlers.
@@ -76,7 +77,7 @@ function ensureWarmedUp(): Promise<void> {
 
 export const app = new Elysia({ adapter: CloudflareAdapter })
   .onBeforeHandle(async ({ path, set }) => {
-    if (path === "/api/v1/health" || path.startsWith("/api/v1/auth/")) return;
+    if (path === "/api/v1/health" || path.startsWith("/api/v1/auth/") || path.startsWith("/api/v1/users/")) return;
     try {
       await ensureWarmedUp();
     } catch {
@@ -87,7 +88,7 @@ export const app = new Elysia({ adapter: CloudflareAdapter })
   .use(
     cors({
       origin: true, // Reflect any Origin — public API, browser requests from any site are allowed
-      methods: ["GET", "HEAD", "POST", "OPTIONS"],
+      methods: ["GET", "HEAD", "POST", "DELETE", "OPTIONS"],
     }),
   )
   .use(
@@ -96,7 +97,8 @@ export const app = new Elysia({ adapter: CloudflareAdapter })
       .use(cardsRoutes(cardProvider))
       .use(setsRoutes(cardProvider))
       .use(decksRoutes(deckProvider))
-      .use(authRoutes()),
+      .use(authRoutes())
+      .use(usersRoutes()),
   )
   .compile();
 

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -19,6 +19,12 @@
  *   POST /api/v1/auth/refresh   body: { refresh_token }
  *   POST /api/v1/auth/logout    Authorization: Bearer <access_token>
  *   GET  /api/v1/auth/me        Authorization: Bearer <access_token>  (protected)
+ *   GET  /api/v1/auth/metafy/status        (protected)
+ *   GET  /api/v1/auth/metafy/connect       (protected)
+ *   POST /api/v1/auth/metafy/callback      (protected)
+ *   DELETE /api/v1/auth/metafy/disconnect  (protected)
+ *   POST /api/v1/auth/metafy/refresh-status (protected)
+ *   POST /api/v1/webhooks/metafy           (public — HMAC signature verified)
  *
  * Deploy: wrangler deploy
  * Dev:    wrangler dev
@@ -43,6 +49,8 @@ import { setsRoutes } from "./routes/sets";
 import { decksRoutes } from "./routes/decks";
 import { authRoutes } from "./routes/auth";
 import { usersRoutes } from "./routes/users";
+import { metafyRoutes } from "./routes/metafy";
+import { handleMetafyWebhook } from "./lib/metafy";
 
 // ─── Singletons ───────────────────────────────────────────────────────────────
 // CF Workers forbid async I/O (fetch) in global scope — only inside handlers.
@@ -77,7 +85,12 @@ function ensureWarmedUp(): Promise<void> {
 
 export const app = new Elysia({ adapter: CloudflareAdapter })
   .onBeforeHandle(async ({ path, set }) => {
-    if (path === "/api/v1/health" || path.startsWith("/api/v1/auth/") || path.startsWith("/api/v1/users/")) return;
+    if (
+      path === "/api/v1/health" ||
+      path.startsWith("/api/v1/auth/") ||
+      path.startsWith("/api/v1/users/") ||
+      path.startsWith("/api/v1/webhooks/")
+    ) return;
     try {
       await ensureWarmedUp();
     } catch {
@@ -98,9 +111,22 @@ export const app = new Elysia({ adapter: CloudflareAdapter })
       .use(setsRoutes(cardProvider))
       .use(decksRoutes(deckProvider))
       .use(authRoutes())
-      .use(usersRoutes()),
+      .use(usersRoutes())
+      .use(metafyRoutes()),
   )
   .compile();
 
 export type App = typeof app;
-export default app;
+
+// The webhook handler needs the raw request body for HMAC signature verification.
+// Elysia's body parser consumes the body stream before our route handler runs,
+// so we intercept the webhook path here, before mounting Elysia.
+export default {
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    if (url.pathname === "/api/v1/webhooks/metafy" && request.method === "POST") {
+      return handleMetafyWebhook(request);
+    }
+    return Promise.resolve(app.fetch(request));
+  },
+};

--- a/packages/api/src/lib/metafy.ts
+++ b/packages/api/src/lib/metafy.ts
@@ -1,0 +1,234 @@
+import { authAdminClient } from "./supabase";
+
+// ─── Webhook ──────────────────────────────────────────────────────────────────
+
+interface WebhookSubscriptionData {
+  id: string;
+  user_id: string;
+  email: string;
+  community_id: string;
+  tier_id?: string;
+  tier_name?: string;
+}
+
+interface MetafyWebhookPayload {
+  id: string;
+  version: string;
+  type: string;
+  occurred_at: string;
+  account_id: string;
+  data: WebhookSubscriptionData;
+}
+
+async function verifyWebhookSignature(
+  secret: string,
+  signature: string,
+  timestamp: string,
+  rawBody: string,
+): Promise<boolean> {
+  const message = `${timestamp}.${rawBody}`;
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const mac = await crypto.subtle.sign("HMAC", key, encoder.encode(message));
+  const hex = Array.from(new Uint8Array(mac))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  const expected = `sha256=${hex}`;
+
+  if (signature.length !== expected.length) return false;
+  let diff = 0;
+  for (let i = 0; i < signature.length; i++) {
+    diff |= signature.charCodeAt(i) ^ expected.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+export async function handleMetafyWebhook(request: Request): Promise<Response> {
+  const webhookSecret = process.env.METAFY_WEBHOOK_SECRET;
+  if (!webhookSecret) {
+    return new Response("Webhook not configured", { status: 503 });
+  }
+
+  const signature = request.headers.get("x-webhook-signature") ?? "";
+  const timestamp = request.headers.get("x-webhook-timestamp") ?? "";
+
+  if (!signature || !timestamp) {
+    return new Response("Missing webhook headers", { status: 400 });
+  }
+
+  // Reject events older than 5 minutes
+  const eventTime = new Date(timestamp).getTime();
+  if (isNaN(eventTime) || Date.now() - eventTime > 5 * 60 * 1000) {
+    return new Response("Timestamp too old", { status: 400 });
+  }
+
+  const rawBody = await request.text();
+
+  const valid = await verifyWebhookSignature(webhookSecret, signature, timestamp, rawBody);
+  if (!valid) {
+    return new Response("Invalid signature", { status: 401 });
+  }
+
+  let payload: MetafyWebhookPayload;
+  try {
+    payload = JSON.parse(rawBody) as MetafyWebhookPayload;
+  } catch {
+    return new Response("Invalid JSON body", { status: 400 });
+  }
+
+  // Process asynchronously — respond 200 first, then update DB
+  void processWebhookEvent(payload);
+
+  return new Response("OK", { status: 200 });
+}
+
+async function processWebhookEvent(payload: MetafyWebhookPayload): Promise<void> {
+  if (!authAdminClient) return;
+
+  const { type, data } = payload;
+  const metafyUserId = data?.user_id;
+  if (!metafyUserId) return;
+
+  const { data: linked } = await authAdminClient
+    .from("linked_accounts")
+    .select("user_id")
+    .eq("provider", "metafy")
+    .eq("provider_user_id", metafyUserId)
+    .maybeSingle();
+
+  if (!linked) return; // User hasn't linked their Riftseer account yet
+
+  const now = new Date().toISOString();
+
+  if (type === "member.joined") {
+    await authAdminClient
+      .from("linked_accounts")
+      .update({ is_member: true, status_checked_at: now })
+      .eq("user_id", linked.user_id)
+      .eq("provider", "metafy");
+    return;
+  }
+
+  if (type === "member.left") {
+    // Left the community entirely — remove both member and supporter status
+    await authAdminClient
+      .from("linked_accounts")
+      .update({ is_member: false, is_supporter: false, status_checked_at: now })
+      .eq("user_id", linked.user_id)
+      .eq("provider", "metafy");
+    return;
+  }
+
+  // Subscription events
+  switch (type) {
+    case "subscription.created":
+    case "subscription.renewed":
+    case "subscription.upgraded":
+    case "subscription.downgraded":
+      // Subscribers are always members
+      await authAdminClient
+        .from("linked_accounts")
+        .update({ is_supporter: true, is_member: true, status_checked_at: now })
+        .eq("user_id", linked.user_id)
+        .eq("provider", "metafy");
+      break;
+    case "subscription.expired":
+    case "subscription.canceled":
+      // Only remove supporter status — they may remain a free member
+      await authAdminClient
+        .from("linked_accounts")
+        .update({ is_supporter: false, status_checked_at: now })
+        .eq("user_id", linked.user_id)
+        .eq("provider", "metafy");
+      break;
+  }
+}
+
+export const METAFY_AUTHORIZE_URL = "https://metafy.gg/auth/authorize";
+export const METAFY_TOKEN_URL = "https://metafy.gg/irk/oauth/token";
+export const METAFY_API_BASE = "https://metafy.gg/irk/api";
+export const METAFY_SCOPES = "profile purchases community";
+
+/**
+ * Calls GET /v1/community/list-joined-communities to check if the user
+ * is a member of our community (free or paid). Returns null on error.
+ */
+export async function checkMetafyMembership(
+  accessToken: string,
+  communityId: string,
+): Promise<boolean | null> {
+  try {
+    const res = await fetch(`${METAFY_API_BASE}/v1/community/list-joined-communities`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    if (!res.ok) return null;
+    const data = (await res.json().catch(() => null)) as {
+      communities?: Array<{ id?: string; community_id?: string }>;
+    } | null;
+    if (!data?.communities) return null;
+    return data.communities.some(
+      (c) => c.id === communityId || c.community_id === communityId,
+    );
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Calls GET /v1/me/purchases/communities/{communityId} with the stored access
+ * token to check active supporter status. 200 + has_access = true means
+ * supporter; 404 means no subscription; 401 means expired token.
+ *
+ * Updates linked_accounts.is_supporter and status_checked_at in place.
+ * Returns the new supporter boolean. Non-2xx (except 404) is treated as unknown
+ * and leaves the existing value unchanged (returns false on first call).
+ */
+export async function refreshMetafySupporterStatus(
+  userId: string,
+  accessToken: string,
+  communityId: string,
+): Promise<boolean> {
+  let isSupporter = false;
+  let gotDefinitiveAnswer = false;
+
+  try {
+    const res = await fetch(
+      `${METAFY_API_BASE}/v1/me/purchases/communities/${encodeURIComponent(communityId)}`,
+      { headers: { Authorization: `Bearer ${accessToken}` } },
+    );
+
+    if (res.ok) {
+      const data = (await res.json().catch(() => null)) as {
+        community?: { has_access?: boolean };
+      } | null;
+      isSupporter = data?.community?.has_access === true;
+      gotDefinitiveAnswer = true;
+    } else if (res.status === 404 || res.status === 403) {
+      // 404 = no subscription to this community; 403 = not authorized
+      isSupporter = false;
+      gotDefinitiveAnswer = true;
+    }
+    // 401 = token expired; 5xx = upstream error — skip update, return false
+  } catch {
+    // Network error — best-effort, skip update
+  }
+
+  if (gotDefinitiveAnswer && authAdminClient) {
+    await authAdminClient
+      .from("linked_accounts")
+      .update({
+        is_supporter: isSupporter,
+        status_checked_at: new Date().toISOString(),
+      })
+      .eq("user_id", userId)
+      .eq("provider", "metafy");
+  }
+
+  return isSupporter;
+}

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -433,6 +433,110 @@ export function authRoutes() {
             },
           )
 
+          // ── PATCH /auth/email ───────────────────────────────────────────
+          .patch(
+            "/auth/email",
+            async ({ body, headers, set }) => {
+              if (!supabaseUrl || !supabaseAnonKey) {
+                set.status = 503;
+                return { error: "Auth service unavailable", code: "SERVICE_UNAVAILABLE" };
+              }
+              const accessToken = headers.authorization!.slice(7);
+              let res: Response;
+              try {
+                res = await fetch(`${supabaseUrl}/auth/v1/user`, {
+                  method: "PATCH",
+                  headers: {
+                    Authorization: `Bearer ${accessToken}`,
+                    apikey: supabaseAnonKey,
+                    "Content-Type": "application/json",
+                  },
+                  body: JSON.stringify({ email: body.email }),
+                });
+              } catch {
+                set.status = 503;
+                return { error: "Auth service unavailable", code: "SERVICE_UNAVAILABLE" };
+              }
+              if (!res.ok) {
+                const payload = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+                set.status = res.status >= 500 ? 503 : res.status === 401 ? 401 : 400;
+                return {
+                  error: String(payload.error_description ?? payload.msg ?? "Email update failed"),
+                  code: "UPDATE_FAILED",
+                };
+              }
+              return { message: "A confirmation email has been sent to your new address." };
+            },
+            {
+              body: t.Object({
+                email: t.String({ description: "New email address" }),
+              }),
+              response: {
+                200: t.Object({ message: t.String() }),
+                400: ErrorSchema,
+                401: ErrorSchema,
+                503: ErrorSchema,
+              },
+              detail: {
+                tags: ["Auth"],
+                summary: "Update email",
+                description:
+                  "Initiates an email change. Supabase sends a confirmation link to the new address.",
+              },
+            },
+          )
+
+          // ── PATCH /auth/change-password ─────────────────────────────────
+          .patch(
+            "/auth/change-password",
+            async ({ body, user, headers, set }) => {
+              if (!authClient || !authAdminClient || !supabaseUrl || !supabaseAnonKey) {
+                set.status = 503;
+                return { error: "Auth service unavailable", code: "SERVICE_UNAVAILABLE" };
+              }
+              if (!user.email) {
+                set.status = 400;
+                return { error: "Account has no email address.", code: "NO_EMAIL" };
+              }
+              // Verify current password
+              const { error: signInError } = await authClient.auth.signInWithPassword({
+                email: user.email,
+                password: body.current_password,
+              });
+              if (signInError) {
+                set.status = 401;
+                return { error: "Current password is incorrect.", code: "INVALID_CREDENTIALS" };
+              }
+              // Update password using admin client
+              const { error: updateError } = await authAdminClient.auth.admin.updateUserById(user.id, {
+                password: body.new_password,
+              });
+              if (updateError) {
+                set.status = 500;
+                return { error: "Failed to update password.", code: "UPDATE_FAILED" };
+              }
+              return { message: "Password updated successfully." };
+            },
+            {
+              body: t.Object({
+                current_password: t.String({ description: "Current account password" }),
+                new_password: t.String({ minLength: 8, description: "New password (min 8 characters)" }),
+              }),
+              response: {
+                200: t.Object({ message: t.String() }),
+                400: ErrorSchema,
+                401: ErrorSchema,
+                500: ErrorSchema,
+                503: ErrorSchema,
+              },
+              detail: {
+                tags: ["Auth"],
+                summary: "Change password",
+                description: "Changes the authenticated user's password. Requires the current password for verification.",
+              },
+            },
+          )
+
           // ── POST /auth/reset-password ────────────────────────────────────
           .post(
             "/auth/reset-password",

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -12,6 +12,8 @@ const SessionSchema = t.Object({
     id: t.String({ description: "User UUID" }),
     email: t.Optional(t.String()),
     created_at: t.String(),
+    handle: t.Optional(t.String({ description: "Unique @handle" })),
+    username: t.Optional(t.String({ description: "Display name" })),
   }),
 });
 
@@ -33,7 +35,7 @@ export function authRoutes() {
       .post(
         "/auth/register",
         async ({ body, set }) => {
-          if (!authClient) {
+          if (!authClient || !authAdminClient) {
             set.status = 503;
             return { error: "Auth service unavailable", code: "SERVICE_UNAVAILABLE" };
           }
@@ -42,6 +44,15 @@ export function authRoutes() {
             return {
               error: "You must accept the Terms of Service and Privacy Policy.",
               code: "TERMS_REQUIRED",
+            };
+          }
+
+          const handle = body.handle.toLowerCase().trim();
+          if (!/^[a-z0-9_]{3,30}$/.test(handle)) {
+            set.status = 400;
+            return {
+              error: "Handle must be 3–30 characters and contain only lowercase letters, numbers, and underscores.",
+              code: "INVALID_HANDLE",
             };
           }
 
@@ -69,7 +80,7 @@ export function authRoutes() {
             return { error: error.message, code: error.code ?? "AUTH_ERROR" };
           }
 
-          if (data.user && authAdminClient) {
+          if (data.user) {
             const { error: adminError } = await authAdminClient.auth.admin.updateUserById(data.user.id, {
               app_metadata: {
                 ...consentMeta,
@@ -88,12 +99,23 @@ export function authRoutes() {
                 code: "CONSENT_RECORD_FAILED",
               };
             }
-          } else if (data.user && !authAdminClient) {
-            console.warn(
-              "[auth/register] authAdminClient is not configured: app_metadata could not be written; " +
-                "consent was recorded only in user_metadata (editable client-side). user id:",
-              data.user.id,
-            );
+
+            const { error: profileError } = await authAdminClient
+              .from("profiles")
+              .insert({ id: data.user.id, username: body.username.trim(), handle });
+            if (profileError) {
+              console.error("[auth/register] profile insert failed:", profileError.message);
+              const { error: deleteError } = await authAdminClient.auth.admin.deleteUser(data.user.id);
+              if (deleteError) {
+                console.error("[auth/register] rollback deleteUser failed:", deleteError.message);
+              }
+              if (profileError.code === "23505") {
+                set.status = 409;
+                return { error: "That handle is already taken.", code: "HANDLE_TAKEN" };
+              }
+              set.status = 500;
+              return { error: "Registration could not be completed. Please try again.", code: "PROFILE_CREATE_FAILED" };
+            }
           }
 
           if (!data.session) {
@@ -112,6 +134,8 @@ export function authRoutes() {
               id: data.user!.id,
               email: data.user!.email,
               created_at: data.user!.created_at,
+              handle,
+              username: body.username.trim(),
             },
           };
         },
@@ -122,6 +146,8 @@ export function authRoutes() {
             accepted_terms: t.Boolean({
               description: "Must be true — records acceptance of Terms and Privacy Policy at signup.",
             }),
+            username: t.String({ minLength: 1, maxLength: 50, description: "Display name (non-unique)" }),
+            handle: t.String({ minLength: 3, maxLength: 30, description: "Unique @handle (lowercase letters, numbers, underscores)" }),
             options: t.Optional(t.Object({
               redirect_to: t.Optional(t.String({ description: "URL to redirect to after email confirmation. Pass window.location.origin + '/auth/callback'." })),
             })),
@@ -130,6 +156,7 @@ export function authRoutes() {
             200: SessionSchema,
             202: ConfirmationSchema,
             400: ErrorSchema,
+            409: ErrorSchema,
             500: ErrorSchema,
             503: ErrorSchema,
           },
@@ -159,6 +186,17 @@ export function authRoutes() {
             set.status = error.status === 401 ? 401 : (error.status && error.status >= 500) ? 503 : 400;
             return { error: error.message, code: error.code ?? "AUTH_ERROR" };
           }
+
+          let profile: { handle: string; username: string } | null = null;
+          if (authAdminClient) {
+            const { data: prof } = await authAdminClient
+              .from("profiles")
+              .select("handle, username")
+              .eq("id", data.user.id)
+              .single();
+            profile = prof;
+          }
+
           return {
             access_token: data.session.access_token,
             refresh_token: data.session.refresh_token,
@@ -168,6 +206,8 @@ export function authRoutes() {
               id: data.user.id,
               email: data.user.email,
               created_at: data.user.created_at,
+              handle: profile?.handle ?? undefined,
+              username: profile?.username ?? undefined,
             },
           };
         },

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -2,6 +2,7 @@ import { Elysia, t } from "elysia";
 import { authAdminClient, authClient, supabaseUrl, supabaseAnonKey } from "../lib/supabase";
 import { authPlugin } from "../plugins/auth";
 import { ErrorSchema } from "../schemas";
+import { refreshMetafySupporterStatus } from "../lib/metafy";
 
 const SessionSchema = t.Object({
   access_token: t.String({ description: "JWT access token (short-lived)" }),
@@ -197,7 +198,7 @@ export function authRoutes() {
             profile = prof;
           }
 
-          return {
+          const result = {
             access_token: data.session.access_token,
             refresh_token: data.session.refresh_token,
             expires_in: data.session.expires_in,
@@ -210,6 +211,33 @@ export function authRoutes() {
               username: profile?.username ?? undefined,
             },
           };
+
+          // Best-effort: refresh Metafy supporter status in the background on login.
+          // Does not block or affect the login response.
+          const communityId = process.env.METAFY_COMMUNITY_ID;
+          if (authAdminClient && communityId) {
+            void (async () => {
+              try {
+                const { data: linked } = await authAdminClient
+                  .from("linked_accounts")
+                  .select("access_token")
+                  .eq("user_id", data.user.id)
+                  .eq("provider", "metafy")
+                  .maybeSingle();
+                if (linked?.access_token) {
+                  await refreshMetafySupporterStatus(
+                    data.user.id,
+                    linked.access_token as string,
+                    communityId,
+                  );
+                }
+              } catch {
+                // never fail login due to Metafy status check
+              }
+            })();
+          }
+
+          return result;
         },
         {
           body: t.Object({

--- a/packages/api/src/routes/metafy.ts
+++ b/packages/api/src/routes/metafy.ts
@@ -1,0 +1,328 @@
+import { Elysia, t } from "elysia";
+import { authAdminClient } from "../lib/supabase";
+import { authPlugin } from "../plugins/auth";
+import { ErrorSchema } from "../schemas";
+import {
+  METAFY_AUTHORIZE_URL,
+  METAFY_TOKEN_URL,
+  METAFY_SCOPES,
+  METAFY_API_BASE,
+  refreshMetafySupporterStatus,
+  checkMetafyMembership,
+} from "../lib/metafy";
+
+const LinkedAccountSchema = t.Object({
+  provider: t.String(),
+  provider_username: t.Nullable(t.String()),
+  is_supporter: t.Boolean(),
+  is_member: t.Boolean(),
+  linked_at: t.String(),
+  status_checked_at: t.Nullable(t.String()),
+});
+
+const MetafyStatusSchema = t.Union([
+  t.Object({ linked: t.Literal(false) }),
+  t.Intersect([t.Object({ linked: t.Literal(true) }), LinkedAccountSchema]),
+]);
+
+export function metafyRoutes() {
+  return new Elysia().use(
+    new Elysia()
+      .use(authPlugin)
+
+      // ── GET /auth/metafy/status ────────────────────────────────────────────
+      .get(
+        "/auth/metafy/status",
+        async ({ user, set }) => {
+          if (!authAdminClient) {
+            set.status = 503;
+            return { error: "Service unavailable", code: "SERVICE_UNAVAILABLE" };
+          }
+
+          const { data } = await authAdminClient
+            .from("linked_accounts")
+            .select("provider, provider_username, is_supporter, is_member, linked_at, status_checked_at")
+            .eq("user_id", user.id)
+            .eq("provider", "metafy")
+            .maybeSingle();
+
+          if (!data) return { linked: false as const };
+
+          return {
+            linked: true as const,
+            provider: data.provider as string,
+            provider_username: data.provider_username as string | null,
+            is_supporter: data.is_supporter as boolean,
+            is_member: data.is_member as boolean,
+            linked_at: data.linked_at as string,
+            status_checked_at: data.status_checked_at as string | null,
+          };
+        },
+        {
+          response: {
+            200: MetafyStatusSchema,
+            401: ErrorSchema,
+            503: ErrorSchema,
+          },
+          detail: { tags: ["Auth"], summary: "Get Metafy link status" },
+        },
+      )
+
+      // ── GET /auth/metafy/connect ───────────────────────────────────────────
+      .get(
+        "/auth/metafy/connect",
+        async ({ set }) => {
+          const clientId = process.env.METAFY_CLIENT_ID;
+          const redirectUri = process.env.METAFY_REDIRECT_URI;
+
+          if (!clientId || !redirectUri) {
+            set.status = 503;
+            return { error: "Metafy OAuth not configured", code: "NOT_CONFIGURED" };
+          }
+
+          const state = crypto.randomUUID();
+
+          const params = new URLSearchParams({
+            client_id: clientId,
+            redirect_uri: redirectUri,
+            response_type: "code",
+            scope: METAFY_SCOPES,
+            state,
+          });
+
+          return { url: `${METAFY_AUTHORIZE_URL}?${params.toString()}`, state };
+        },
+        {
+          response: {
+            200: t.Object({ url: t.String(), state: t.String() }),
+            401: ErrorSchema,
+            503: ErrorSchema,
+          },
+          detail: { tags: ["Auth"], summary: "Get Metafy OAuth URL" },
+        },
+      )
+
+      // ── POST /auth/metafy/callback ─────────────────────────────────────────
+      .post(
+        "/auth/metafy/callback",
+        async ({ body, user, set }) => {
+          if (!authAdminClient) {
+            set.status = 503;
+            return { error: "Service unavailable", code: "SERVICE_UNAVAILABLE" };
+          }
+
+          const clientId = process.env.METAFY_CLIENT_ID;
+          const clientSecret = process.env.METAFY_CLIENT_SECRET;
+          const redirectUri = process.env.METAFY_REDIRECT_URI;
+          const communityId = process.env.METAFY_COMMUNITY_ID;
+
+          if (!clientId || !clientSecret || !redirectUri || !communityId) {
+            set.status = 503;
+            return { error: "Metafy OAuth not configured", code: "NOT_CONFIGURED" };
+          }
+
+          // Exchange authorization code for tokens
+          let tokenRes: Response;
+          try {
+            tokenRes = await fetch(METAFY_TOKEN_URL, {
+              method: "POST",
+              headers: { "Content-Type": "application/x-www-form-urlencoded" },
+              body: new URLSearchParams({
+                grant_type: "authorization_code",
+                code: body.code,
+                client_id: clientId,
+                client_secret: clientSecret,
+                redirect_uri: redirectUri,
+              }),
+            });
+          } catch {
+            set.status = 502;
+            return { error: "Failed to reach Metafy OAuth server", code: "UPSTREAM_ERROR" };
+          }
+
+          if (!tokenRes.ok) {
+            set.status = 400;
+            return { error: "OAuth token exchange failed", code: "OAUTH_ERROR" };
+          }
+
+          const tokens = (await tokenRes.json()) as {
+            access_token: string;
+            refresh_token?: string;
+          };
+
+          if (!tokens.access_token) {
+            set.status = 400;
+            return { error: "No access token in OAuth response", code: "OAUTH_ERROR" };
+          }
+
+          // Fetch Metafy user profile — GET /v1/me returns { user: { id, slug, name, ... } }
+          let profileRes: Response;
+          try {
+            profileRes = await fetch(`${METAFY_API_BASE}/v1/me`, {
+              headers: { Authorization: `Bearer ${tokens.access_token}` },
+            });
+          } catch {
+            set.status = 502;
+            return { error: "Failed to fetch Metafy profile", code: "UPSTREAM_ERROR" };
+          }
+
+          if (!profileRes.ok) {
+            set.status = 502;
+            return { error: "Failed to fetch Metafy profile", code: "UPSTREAM_ERROR" };
+          }
+
+          const { user: metafyUser } = (await profileRes.json()) as {
+            user: { id: string; slug: string; name: string };
+          };
+
+          const providerUserId = metafyUser.id;
+          const providerUsername = metafyUser.slug ?? metafyUser.name ?? null;
+
+          // Check supporter status and community membership in parallel
+          const [isSupporter, isMemberResult] = await Promise.all([
+            refreshMetafySupporterStatus(user.id, tokens.access_token, communityId),
+            checkMetafyMembership(tokens.access_token, communityId),
+          ]);
+          // Subscribers are always members; non-null membership result overrides
+          const isMember = isSupporter || (isMemberResult ?? false);
+
+          // Upsert linked account
+          const now = new Date().toISOString();
+          const { error: upsertError } = await authAdminClient
+            .from("linked_accounts")
+            .upsert(
+              {
+                user_id: user.id,
+                provider: "metafy",
+                provider_user_id: providerUserId,
+                provider_username: providerUsername,
+                access_token: tokens.access_token,
+                refresh_token: tokens.refresh_token ?? null,
+                is_supporter: isSupporter,
+                is_member: isMember,
+                status_checked_at: now,
+                linked_at: now,
+              },
+              { onConflict: "user_id,provider" },
+            );
+
+          if (upsertError) {
+            set.status = 500;
+            return { error: "Failed to save linked account", code: "DB_ERROR" };
+          }
+
+          return {
+            linked: true as const,
+            provider: "metafy",
+            provider_username: providerUsername,
+            is_supporter: isSupporter,
+            is_member: isMember,
+            linked_at: now,
+            status_checked_at: now,
+          };
+        },
+        {
+          body: t.Object({
+            code: t.String(),
+            state: t.String(),
+          }),
+          response: {
+            200: t.Intersect([t.Object({ linked: t.Literal(true) }), LinkedAccountSchema]),
+            400: ErrorSchema,
+            401: ErrorSchema,
+            500: ErrorSchema,
+            502: ErrorSchema,
+            503: ErrorSchema,
+          },
+          detail: { tags: ["Auth"], summary: "Complete Metafy OAuth callback" },
+        },
+      )
+
+      // ── DELETE /auth/metafy/disconnect ────────────────────────────────────
+      .delete(
+        "/auth/metafy/disconnect",
+        async ({ user, set }) => {
+          if (!authAdminClient) {
+            set.status = 503;
+            return { error: "Service unavailable", code: "SERVICE_UNAVAILABLE" };
+          }
+
+          await authAdminClient
+            .from("linked_accounts")
+            .delete()
+            .eq("user_id", user.id)
+            .eq("provider", "metafy");
+
+          return { message: "Metafy account disconnected" };
+        },
+        {
+          response: {
+            200: t.Object({ message: t.String() }),
+            401: ErrorSchema,
+            503: ErrorSchema,
+          },
+          detail: { tags: ["Auth"], summary: "Disconnect Metafy account" },
+        },
+      )
+
+      // ── POST /auth/metafy/refresh-status ──────────────────────────────────
+      .post(
+        "/auth/metafy/refresh-status",
+        async ({ user, set }) => {
+          if (!authAdminClient) {
+            set.status = 503;
+            return { error: "Service unavailable", code: "SERVICE_UNAVAILABLE" };
+          }
+
+          const communityId = process.env.METAFY_COMMUNITY_ID;
+          if (!communityId) {
+            set.status = 503;
+            return { error: "Metafy OAuth not configured", code: "NOT_CONFIGURED" };
+          }
+
+          const { data: linked } = await authAdminClient
+            .from("linked_accounts")
+            .select("access_token, provider_username, is_member, linked_at")
+            .eq("user_id", user.id)
+            .eq("provider", "metafy")
+            .maybeSingle();
+
+          if (!linked) {
+            set.status = 404;
+            return { error: "No linked Metafy account", code: "NOT_LINKED" };
+          }
+
+          if (!linked.access_token) {
+            set.status = 400;
+            return { error: "No access token stored for Metafy account", code: "NO_TOKEN" };
+          }
+
+          const isSupporter = await refreshMetafySupporterStatus(
+            user.id,
+            linked.access_token as string,
+            communityId,
+          );
+
+          return {
+            linked: true as const,
+            provider: "metafy",
+            provider_username: linked.provider_username as string | null,
+            is_supporter: isSupporter,
+            is_member: (linked.is_member as boolean | null) ?? false,
+            linked_at: linked.linked_at as string,
+            status_checked_at: new Date().toISOString(),
+          };
+        },
+        {
+          response: {
+            200: t.Intersect([t.Object({ linked: t.Literal(true) }), LinkedAccountSchema]),
+            400: ErrorSchema,
+            401: ErrorSchema,
+            404: ErrorSchema,
+            503: ErrorSchema,
+          },
+          detail: { tags: ["Auth"], summary: "Refresh Metafy supporter status" },
+        },
+      ),
+  );
+}

--- a/packages/api/src/routes/users.ts
+++ b/packages/api/src/routes/users.ts
@@ -1,0 +1,322 @@
+import { Elysia, t } from "elysia";
+import { authAdminClient, authClient } from "../lib/supabase";
+import { authPlugin } from "../plugins/auth";
+import { ErrorSchema } from "../schemas";
+
+const ProfileSchema = t.Object({
+  id: t.String(),
+  handle: t.String(),
+  username: t.String(),
+  follower_count: t.Number(),
+  following_count: t.Number(),
+  created_at: t.String(),
+  is_following: t.Optional(t.Boolean()),
+});
+
+const ProfileStubSchema = t.Object({
+  id: t.String(),
+  handle: t.String(),
+  username: t.String(),
+  created_at: t.String(),
+});
+
+const ProfileListSchema = t.Object({
+  items: t.Array(ProfileStubSchema),
+  total: t.Number(),
+});
+
+export function usersRoutes() {
+  return (
+    new Elysia()
+
+      // ── GET /users/:handle ────────────────────────────────────────────────
+      .get(
+        "/users/:handle",
+        async ({ params, headers, set }) => {
+          if (!authAdminClient) {
+            set.status = 503;
+            return { error: "Service unavailable", code: "SERVICE_UNAVAILABLE" };
+          }
+          const handle = params.handle.toLowerCase();
+
+          const { data: profile, error: profileError } = await authAdminClient
+            .from("profiles")
+            .select("id, handle, username, created_at")
+            .eq("handle", handle)
+            .single();
+
+          if (profileError || !profile) {
+            set.status = 404;
+            return { error: "Profile not found", code: "NOT_FOUND" };
+          }
+
+          const [{ count: followerCount }, { count: followingCount }] = await Promise.all([
+            authAdminClient
+              .from("follows")
+              .select("*", { count: "exact", head: true })
+              .eq("following_id", profile.id),
+            authAdminClient
+              .from("follows")
+              .select("*", { count: "exact", head: true })
+              .eq("follower_id", profile.id),
+          ]);
+
+          let isFollowing: boolean | undefined;
+          if (authClient && headers.authorization?.startsWith("Bearer ")) {
+            const token = headers.authorization.slice(7);
+            try {
+              const { data: { user: requester } } = await authClient.auth.getUser(token);
+              if (requester && requester.id !== profile.id) {
+                const { count } = await authAdminClient
+                  .from("follows")
+                  .select("*", { count: "exact", head: true })
+                  .eq("follower_id", requester.id)
+                  .eq("following_id", profile.id);
+                isFollowing = (count ?? 0) > 0;
+              }
+            } catch {
+              // auth is optional on this endpoint
+            }
+          }
+
+          return {
+            id: profile.id as string,
+            handle: profile.handle as string,
+            username: profile.username as string,
+            follower_count: followerCount ?? 0,
+            following_count: followingCount ?? 0,
+            created_at: profile.created_at as string,
+            ...(isFollowing !== undefined ? { is_following: isFollowing } : {}),
+          };
+        },
+        {
+          params: t.Object({ handle: t.String() }),
+          response: {
+            200: ProfileSchema,
+            404: ErrorSchema,
+            503: ErrorSchema,
+          },
+          detail: {
+            tags: ["Users"],
+            summary: "Get user profile",
+            description: "Returns a public user profile by @handle, with follower/following counts.",
+          },
+        },
+      )
+
+      // ── GET /users/:handle/followers ──────────────────────────────────────
+      .get(
+        "/users/:handle/followers",
+        async ({ params, query, set }) => {
+          if (!authAdminClient) {
+            set.status = 503;
+            return { error: "Service unavailable", code: "SERVICE_UNAVAILABLE" };
+          }
+          const handle = params.handle.toLowerCase();
+          const limit = Math.min(query.limit ?? 20, 100);
+          const offset = query.offset ?? 0;
+
+          const { data: target } = await authAdminClient
+            .from("profiles")
+            .select("id")
+            .eq("handle", handle)
+            .single();
+
+          if (!target) {
+            set.status = 404;
+            return { error: "Profile not found", code: "NOT_FOUND" };
+          }
+
+          const { data: rows, count } = await authAdminClient
+            .from("follows")
+            .select("follower_id", { count: "exact" })
+            .eq("following_id", target.id)
+            .range(offset, offset + limit - 1);
+
+          const ids = (rows ?? []).map((r: { follower_id: string }) => r.follower_id);
+          const profiles = ids.length
+            ? ((await authAdminClient
+                .from("profiles")
+                .select("id, handle, username, created_at")
+                .in("id", ids)).data ?? [])
+            : [];
+
+          return { items: profiles, total: count ?? 0 };
+        },
+        {
+          params: t.Object({ handle: t.String() }),
+          query: t.Object({
+            limit: t.Optional(t.Number()),
+            offset: t.Optional(t.Number()),
+          }),
+          response: {
+            200: ProfileListSchema,
+            404: ErrorSchema,
+            503: ErrorSchema,
+          },
+          detail: {
+            tags: ["Users"],
+            summary: "Get followers",
+            description: "Returns a paginated list of profiles that follow the given user.",
+          },
+        },
+      )
+
+      // ── GET /users/:handle/following ──────────────────────────────────────
+      .get(
+        "/users/:handle/following",
+        async ({ params, query, set }) => {
+          if (!authAdminClient) {
+            set.status = 503;
+            return { error: "Service unavailable", code: "SERVICE_UNAVAILABLE" };
+          }
+          const handle = params.handle.toLowerCase();
+          const limit = Math.min(query.limit ?? 20, 100);
+          const offset = query.offset ?? 0;
+
+          const { data: target } = await authAdminClient
+            .from("profiles")
+            .select("id")
+            .eq("handle", handle)
+            .single();
+
+          if (!target) {
+            set.status = 404;
+            return { error: "Profile not found", code: "NOT_FOUND" };
+          }
+
+          const { data: rows, count } = await authAdminClient
+            .from("follows")
+            .select("following_id", { count: "exact" })
+            .eq("follower_id", target.id)
+            .range(offset, offset + limit - 1);
+
+          const ids = (rows ?? []).map((r: { following_id: string }) => r.following_id);
+          const profiles = ids.length
+            ? ((await authAdminClient
+                .from("profiles")
+                .select("id, handle, username, created_at")
+                .in("id", ids)).data ?? [])
+            : [];
+
+          return { items: profiles, total: count ?? 0 };
+        },
+        {
+          params: t.Object({ handle: t.String() }),
+          query: t.Object({
+            limit: t.Optional(t.Number()),
+            offset: t.Optional(t.Number()),
+          }),
+          response: {
+            200: ProfileListSchema,
+            404: ErrorSchema,
+            503: ErrorSchema,
+          },
+          detail: {
+            tags: ["Users"],
+            summary: "Get following",
+            description: "Returns a paginated list of profiles that the given user follows.",
+          },
+        },
+      )
+
+      // ── Protected: follow / unfollow ──────────────────────────────────────
+      .use(
+        new Elysia()
+          .use(authPlugin)
+
+          // POST /users/:handle/follow
+          .post(
+            "/users/:handle/follow",
+            async ({ params, user, set }) => {
+              if (!authAdminClient) {
+                set.status = 503;
+                return { error: "Service unavailable", code: "SERVICE_UNAVAILABLE" };
+              }
+              const handle = params.handle.toLowerCase();
+
+              const { data: target } = await authAdminClient
+                .from("profiles")
+                .select("id")
+                .eq("handle", handle)
+                .single();
+
+              if (!target) {
+                set.status = 404;
+                return { error: "Profile not found", code: "NOT_FOUND" };
+              }
+              if (target.id === user.id) {
+                set.status = 400;
+                return { error: "Cannot follow yourself", code: "SELF_FOLLOW" };
+              }
+
+              const { error: followError } = await authAdminClient
+                .from("follows")
+                .insert({ follower_id: user.id, following_id: target.id });
+
+              if (followError) {
+                if (followError.code === "23505") {
+                  return { message: "Already following" };
+                }
+                set.status = 500;
+                return { error: "Failed to follow", code: "FOLLOW_FAILED" };
+              }
+
+              return { message: "Followed successfully" };
+            },
+            {
+              params: t.Object({ handle: t.String() }),
+              response: {
+                200: t.Object({ message: t.String() }),
+                400: ErrorSchema,
+                401: ErrorSchema,
+                404: ErrorSchema,
+                503: ErrorSchema,
+              },
+              detail: { tags: ["Users"], summary: "Follow user" },
+            },
+          )
+
+          // DELETE /users/:handle/follow
+          .delete(
+            "/users/:handle/follow",
+            async ({ params, user, set }) => {
+              if (!authAdminClient) {
+                set.status = 503;
+                return { error: "Service unavailable", code: "SERVICE_UNAVAILABLE" };
+              }
+              const handle = params.handle.toLowerCase();
+
+              const { data: target } = await authAdminClient
+                .from("profiles")
+                .select("id")
+                .eq("handle", handle)
+                .single();
+
+              if (!target) {
+                set.status = 404;
+                return { error: "Profile not found", code: "NOT_FOUND" };
+              }
+
+              await authAdminClient
+                .from("follows")
+                .delete()
+                .eq("follower_id", user.id)
+                .eq("following_id", target.id);
+
+              return { message: "Unfollowed successfully" };
+            },
+            {
+              params: t.Object({ handle: t.String() }),
+              response: {
+                200: t.Object({ message: t.String() }),
+                401: ErrorSchema,
+                404: ErrorSchema,
+                503: ErrorSchema,
+              },
+              detail: { tags: ["Users"], summary: "Unfollow user" },
+            },
+          ),
+      )
+  );
+}

--- a/packages/api/src/routes/users.ts
+++ b/packages/api/src/routes/users.ts
@@ -1,4 +1,5 @@
 import { Elysia, t } from "elysia";
+import { SOCIAL_PLATFORM_IDS, validateSocialLink } from "@riftseer/types/social-links";
 import { authAdminClient, authClient } from "../lib/supabase";
 import { authPlugin } from "../plugins/auth";
 import { ErrorSchema } from "../schemas";
@@ -7,6 +8,9 @@ const ProfileSchema = t.Object({
   id: t.String(),
   handle: t.String(),
   username: t.String(),
+  bio: t.Nullable(t.String()),
+  pronouns: t.Array(t.String()),
+  social_links: t.Record(t.String(), t.String()),
   follower_count: t.Number(),
   following_count: t.Number(),
   created_at: t.String(),
@@ -27,6 +31,9 @@ const ProfileListSchema = t.Object({
   total: t.Number(),
 });
 
+const HANDLE_RE = /^[a-z0-9_]{3,30}$/;
+const SOCIAL_LINK_MAX = 500;
+
 export function usersRoutes() {
   return (
     new Elysia()
@@ -43,11 +50,23 @@ export function usersRoutes() {
 
           const { data: profile, error: profileError } = await authAdminClient
             .from("profiles")
-            .select("id, handle, username, created_at")
+            .select("id, handle, username, bio, pronouns, social_links, created_at")
             .eq("handle", handle)
             .single();
 
-          if (profileError || !profile) {
+          if (profileError) {
+            // PGRST116 = no rows matched → genuine 404
+            if (profileError.code === "PGRST116") {
+              set.status = 404;
+              return { error: "Profile not found", code: "NOT_FOUND" };
+            }
+            // Any other DB error (e.g. unknown column) → schema mismatch or transient failure
+            console.error("[users/:handle] profile query error:", profileError.code, profileError.message);
+            set.status = 503;
+            return { error: "Service unavailable", code: "SERVICE_UNAVAILABLE" };
+          }
+
+          if (!profile) {
             set.status = 404;
             return { error: "Profile not found", code: "NOT_FOUND" };
           }
@@ -92,6 +111,9 @@ export function usersRoutes() {
             id: profile.id as string,
             handle: profile.handle as string,
             username: profile.username as string,
+            bio: (profile.bio as string | null) ?? null,
+            pronouns: (profile.pronouns as string[] | null) ?? [],
+            social_links: (profile.social_links as Record<string, string> | null) ?? {},
             follower_count: followerCount ?? 0,
             following_count: followingCount ?? 0,
             created_at: profile.created_at as string,
@@ -231,12 +253,171 @@ export function usersRoutes() {
         },
       )
 
-      // ── Protected: follow / unfollow ──────────────────────────────────────
+      // ── Protected routes ──────────────────────────────────────────────────
       .use(
         new Elysia()
           .use(authPlugin)
 
-          // POST /users/:handle/follow
+          // ── PATCH /users/me ─────────────────────────────────────────────
+          .patch(
+            "/users/me",
+            async ({ user, body, set }) => {
+              if (!authAdminClient) {
+                set.status = 503;
+                return { error: "Service unavailable", code: "SERVICE_UNAVAILABLE" };
+              }
+
+              const updates: Record<string, unknown> = { updated_at: new Date().toISOString() };
+
+              if (body.username !== undefined) {
+                const username = body.username.trim();
+                if (username.length < 1 || username.length > 50) {
+                  set.status = 400;
+                  return { error: "Display name must be 1–50 characters.", code: "INVALID_USERNAME" };
+                }
+                updates.username = username;
+              }
+
+              if (body.handle !== undefined) {
+                const handle = body.handle.toLowerCase().trim();
+                if (!HANDLE_RE.test(handle)) {
+                  set.status = 400;
+                  return {
+                    error: "Handle must be 3–30 characters: lowercase letters, numbers, underscores only.",
+                    code: "INVALID_HANDLE",
+                  };
+                }
+                const { data: existing } = await authAdminClient
+                  .from("profiles")
+                  .select("id")
+                  .eq("handle", handle)
+                  .neq("id", user.id)
+                  .maybeSingle();
+                if (existing) {
+                  set.status = 409;
+                  return { error: "That handle is already taken.", code: "HANDLE_TAKEN" };
+                }
+                updates.handle = handle;
+              }
+
+              if (body.bio !== undefined) {
+                const bio = body.bio.trim();
+                if (bio.length > 300) {
+                  set.status = 400;
+                  return { error: "Bio must be 300 characters or fewer.", code: "INVALID_BIO" };
+                }
+                updates.bio = bio || null;
+              }
+
+              if (body.pronouns !== undefined) {
+                const pronouns = body.pronouns
+                  .map((p) => p.trim())
+                  .filter(Boolean)
+                  .slice(0, 3);
+                updates.pronouns = pronouns;
+              }
+
+              if (body.social_links !== undefined) {
+                const cleaned: Record<string, string> = {};
+                for (const [k, v] of Object.entries(body.social_links)) {
+                  if (!(SOCIAL_PLATFORM_IDS as readonly string[]).includes(k)) continue;
+
+                  const val = String(v).trim();
+                  if (!val) continue;
+
+                  const linkError = validateSocialLink(k, val);
+                  if (linkError) {
+                    set.status = 400;
+                    return { error: linkError, code: "INVALID_SOCIAL_LINK" };
+                  }
+                  if (val.length > SOCIAL_LINK_MAX) {
+                    set.status = 400;
+                    return {
+                      error: `Social link must be ${SOCIAL_LINK_MAX} characters or fewer.`,
+                      code: "INVALID_SOCIAL_LINK",
+                    };
+                  }
+                  cleaned[k] = val;
+                }
+                updates.social_links = cleaned;
+              }
+
+              const { error } = await authAdminClient
+                .from("profiles")
+                .update(updates)
+                .eq("id", user.id);
+
+              if (error) {
+                if (error.code === "23505") {
+                  set.status = 409;
+                  return { error: "That handle is already taken.", code: "HANDLE_TAKEN" };
+                }
+                set.status = 500;
+                return { error: "Failed to update profile.", code: "UPDATE_FAILED" };
+              }
+
+              return {
+                message: "Profile updated.",
+                handle: updates.handle as string | undefined,
+                username: updates.username as string | undefined,
+              };
+            },
+            {
+              body: t.Object({
+                username: t.Optional(t.String({ minLength: 1, maxLength: 50 })),
+                handle: t.Optional(t.String({ minLength: 3, maxLength: 30 })),
+                bio: t.Optional(t.String({ maxLength: 300 })),
+                pronouns: t.Optional(t.Array(t.String(), { maxItems: 3 })),
+                social_links: t.Optional(t.Record(t.String(), t.String())),
+              }),
+              response: {
+                200: t.Object({
+                  message: t.String(),
+                  handle: t.Optional(t.String()),
+                  username: t.Optional(t.String()),
+                }),
+                400: ErrorSchema,
+                401: ErrorSchema,
+                409: ErrorSchema,
+                500: ErrorSchema,
+                503: ErrorSchema,
+              },
+              detail: { tags: ["Users"], summary: "Update own profile" },
+            },
+          )
+
+          // ── DELETE /users/me ────────────────────────────────────────────
+          .delete(
+            "/users/me",
+            async ({ user, set }) => {
+              if (!authAdminClient) {
+                set.status = 503;
+                return { error: "Service unavailable", code: "SERVICE_UNAVAILABLE" };
+              }
+
+              // profiles row cascades from auth.users, but delete explicitly in case RLS blocks cascade
+              await authAdminClient.from("profiles").delete().eq("id", user.id);
+
+              const { error } = await authAdminClient.auth.admin.deleteUser(user.id);
+              if (error) {
+                set.status = 500;
+                return { error: "Failed to delete account.", code: "DELETE_FAILED" };
+              }
+
+              return { message: "Account deleted." };
+            },
+            {
+              response: {
+                200: t.Object({ message: t.String() }),
+                401: ErrorSchema,
+                500: ErrorSchema,
+                503: ErrorSchema,
+              },
+              detail: { tags: ["Users"], summary: "Delete own account" },
+            },
+          )
+
+          // ── POST /users/:handle/follow ───────────────────────────────────
           .post(
             "/users/:handle/follow",
             async ({ params, user, set }) => {
@@ -288,7 +469,7 @@ export function usersRoutes() {
             },
           )
 
-          // DELETE /users/:handle/follow
+          // ── DELETE /users/:handle/follow ─────────────────────────────────
           .delete(
             "/users/:handle/follow",
             async ({ params, user, set }) => {

--- a/packages/api/src/routes/users.ts
+++ b/packages/api/src/routes/users.ts
@@ -11,6 +11,8 @@ const ProfileSchema = t.Object({
   following_count: t.Number(),
   created_at: t.String(),
   is_following: t.Optional(t.Boolean()),
+  is_supporter: t.Boolean(),
+  is_member: t.Boolean(),
 });
 
 const ProfileStubSchema = t.Object({
@@ -79,6 +81,13 @@ export function usersRoutes() {
             }
           }
 
+          const { data: linked } = await authAdminClient
+            .from("linked_accounts")
+            .select("is_supporter, is_member")
+            .eq("user_id", profile.id)
+            .eq("provider", "metafy")
+            .maybeSingle();
+
           return {
             id: profile.id as string,
             handle: profile.handle as string,
@@ -86,6 +95,8 @@ export function usersRoutes() {
             follower_count: followerCount ?? 0,
             following_count: followingCount ?? 0,
             created_at: profile.created_at as string,
+            is_supporter: (linked?.is_supporter as boolean | null) ?? false,
+            is_member: (linked?.is_member as boolean | null) ?? false,
             ...(isFollowing !== undefined ? { is_following: isFollowing } : {}),
           };
         },

--- a/packages/api/wrangler.jsonc
+++ b/packages/api/wrangler.jsonc
@@ -14,12 +14,16 @@
 		"LEGAL_PRIVACY_VERSION": "1",
 		// Public site origin used to build absolute riftseer_uri values on every
 		// card response. Override per-environment if needed.
-		"SITE_ORIGIN": "https://riftseer.com"
+		"SITE_ORIGIN": "https://riftseer.com",
 	},
 	// Required for core API + Supabase auth routes.
 	// Optional secrets (omit from required): UPSTASH_REDIS_REST_URL, UPSTASH_REDIS_REST_TOKEN, TCGPLAYER_AFFILIATE_ID
 	// https://developers.cloudflare.com/workers/wrangler/configuration/#secrets-configuration-property
+	// METAFY_CLIENT_SECRET — set via: wrangler secret put METAFY_CLIENT_SECRET
+	// METAFY_WEBHOOK_SECRET — optional, set via: wrangler secret put METAFY_WEBHOOK_SECRET (Partners only)
+	// "METAFY_COMMUNITY_ID": "riftseer", 
+	// "METAFY_REDIRECT_URI": "{web_domain}/auth/metafy/callback"
 	"secrets": {
-		"required": ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY", "SUPABASE_ANON_KEY"]
+		"required": ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY", "SUPABASE_ANON_KEY", "METAFY_CLIENT_SECRET", "METAFY_REDIRECT_URI", "METAFY_COMMUNITY_ID", "METAFY_CLIENT_ID"]
 	}
 }

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -2,3 +2,4 @@ export * from "./src/card.ts";
 export * from "./src/parser.ts";
 export * from "./src/icons.ts";
 export * from "./src/slug.ts";
+export * from "./src/social-links.ts";

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -8,7 +8,11 @@
     ".": "./index.ts",
     "./icons": "./src/icons.ts",
     "./parser": "./src/parser.ts",
-    "./slug": "./src/slug.ts"
+    "./slug": "./src/slug.ts",
+    "./social-links": "./src/social-links.ts"
+  },
+  "scripts": {
+    "test": "bun test src/__tests__"
   },
   "devDependencies": {
     "bun-types": "^1.2.0"

--- a/packages/types/src/__tests__/social-links.test.ts
+++ b/packages/types/src/__tests__/social-links.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { validateSocialLink } from "../social-links.ts";
+
+describe("validateSocialLink", () => {
+  test("kick accepts channel URLs", () => {
+    expect(validateSocialLink("kick", "https://kick.com/xqc")).toBeNull();
+    expect(validateSocialLink("kick", "kick.com/EggsLeggs")).toBeNull();
+  });
+
+  test("kick rejects non-channel pages", () => {
+    expect(validateSocialLink("kick", "https://kick.com/category/just-chatting")).not.toBeNull();
+    expect(validateSocialLink("kick", "https://kick.com/xqc/videos")).not.toBeNull();
+    expect(validateSocialLink("kick", "https://kick.com/categories")).not.toBeNull();
+  });
+
+  test("kick rejects other platforms", () => {
+    expect(validateSocialLink("kick", "https://github.com/EggsLeggs")).not.toBeNull();
+    expect(validateSocialLink("kick", "https://twitch.tv/xqc")).not.toBeNull();
+  });
+
+  test("youtube accepts channel URLs", () => {
+    expect(validateSocialLink("youtube", "https://youtube.com/@channel")).toBeNull();
+    expect(validateSocialLink("youtube", "https://youtube.com/c/MyChannel")).toBeNull();
+  });
+
+  test("youtube rejects video URLs", () => {
+    expect(validateSocialLink("youtube", "https://youtu.be/dQw4w9WgXcQ")).not.toBeNull();
+    expect(validateSocialLink("youtube", "https://youtube.com/watch?v=abc")).not.toBeNull();
+  });
+
+  test("twitter rejects status URLs", () => {
+    expect(validateSocialLink("twitter", "https://x.com/someuser")).toBeNull();
+    expect(validateSocialLink("twitter", "https://x.com/someuser/status/123")).not.toBeNull();
+  });
+
+  test("discord accepts invite and username", () => {
+    expect(validateSocialLink("discord", "https://discord.gg/abc123")).toBeNull();
+    expect(validateSocialLink("discord", "myusername")).toBeNull();
+  });
+
+  test("reddit accepts profile URLs", () => {
+    expect(validateSocialLink("reddit", "https://reddit.com/u/spez")).toBeNull();
+    expect(validateSocialLink("reddit", "https://reddit.com/r/all")).not.toBeNull();
+  });
+});

--- a/packages/types/src/social-links.ts
+++ b/packages/types/src/social-links.ts
@@ -1,0 +1,308 @@
+/** Platform ids — keep in sync with `packages/web/src/lib/social-platforms.ts`. */
+export const SOCIAL_PLATFORM_IDS = [
+  "kick",
+  "youtube",
+  "twitch",
+  "instagram",
+  "facebook",
+  "linkedin",
+  "discord",
+  "kofi",
+  "patreon",
+  "bluesky",
+  "twitter",
+  "reddit",
+] as const;
+
+export type SocialPlatformId = (typeof SOCIAL_PLATFORM_IDS)[number];
+
+const PLATFORM_LABELS: Record<SocialPlatformId, string> = {
+  kick: "Kick",
+  youtube: "YouTube",
+  twitch: "Twitch",
+  instagram: "Instagram",
+  facebook: "Facebook",
+  linkedin: "LinkedIn",
+  discord: "Discord",
+  kofi: "Ko-fi",
+  patreon: "Patreon",
+  bluesky: "Bluesky",
+  twitter: "X / Twitter",
+  reddit: "Reddit",
+};
+
+const KICK_RESERVED = new Set([
+  "about",
+  "browse",
+  "categories",
+  "category",
+  "dashboard",
+  "directory",
+  "search",
+  "settings",
+  "video",
+  "videos",
+]);
+
+function stripWww(host: string): string {
+  return host.replace(/^www\./i, "");
+}
+
+function parseHttpUrl(value: string): URL | null {
+  try {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const withProto = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+    return new URL(withProto);
+  } catch {
+    return null;
+  }
+}
+
+function pathSegments(pathname: string): string[] {
+  return pathname.split("/").filter(Boolean);
+}
+
+function wrongHost(platform: SocialPlatformId): string {
+  return `URL must be from ${PLATFORM_LABELS[platform]}.`;
+}
+
+function validateKick(value: string): string | null {
+  const url = parseHttpUrl(value);
+  if (!url) return "Enter a valid Kick profile URL (e.g. https://kick.com/username).";
+  if (stripWww(url.hostname) !== "kick.com") return wrongHost("kick");
+
+  const segments = pathSegments(url.pathname);
+  if (segments.length !== 1) {
+    return "Enter a Kick channel URL (kick.com/username), not another page.";
+  }
+
+  const slug = segments[0]!;
+  if (KICK_RESERVED.has(slug.toLowerCase())) {
+    return "Enter a Kick channel URL, not a site page.";
+  }
+  if (!/^[a-zA-Z0-9_]{1,25}$/.test(slug)) {
+    return "Invalid Kick username.";
+  }
+  return null;
+}
+
+function validateYoutube(value: string): string | null {
+  const url = parseHttpUrl(value);
+  if (!url) return "Enter a valid YouTube channel URL.";
+  const host = stripWww(url.hostname);
+  if (host === "youtu.be") return "Use a channel URL, not a video link.";
+  if (!["youtube.com", "m.youtube.com"].includes(host)) return wrongHost("youtube");
+
+  const path = url.pathname;
+  if (
+    /^\/@[^/]+\/?$/.test(path) ||
+    /^\/c\/[^/]+\/?$/.test(path) ||
+    /^\/channel\/[^/]+\/?$/.test(path) ||
+    /^\/user\/[^/]+\/?$/.test(path)
+  ) {
+    return null;
+  }
+  return "Enter a YouTube channel URL (e.g. youtube.com/@channel).";
+}
+
+function validateTwitch(value: string): string | null {
+  const url = parseHttpUrl(value);
+  if (!url) return "Enter a valid Twitch profile URL.";
+  if (stripWww(url.hostname) !== "twitch.tv") return wrongHost("twitch");
+
+  const segments = pathSegments(url.pathname);
+  if (segments.length !== 1 || !/^[a-zA-Z0-9_]{1,25}$/.test(segments[0]!)) {
+    return "Enter a Twitch channel URL (twitch.tv/username).";
+  }
+  return null;
+}
+
+function validateInstagram(value: string): string | null {
+  const url = parseHttpUrl(value);
+  if (!url) return "Enter a valid Instagram profile URL.";
+  if (!["instagram.com", "m.instagram.com"].includes(stripWww(url.hostname))) {
+    return wrongHost("instagram");
+  }
+
+  const segments = pathSegments(url.pathname);
+  const blocked = new Set(["p", "reel", "reels", "stories", "explore", "tv", "accounts"]);
+  if (segments.length !== 1 || blocked.has(segments[0]!.toLowerCase())) {
+    return "Enter an Instagram profile URL (instagram.com/username).";
+  }
+  if (!/^[a-zA-Z0-9._]{1,30}$/.test(segments[0]!)) {
+    return "Invalid Instagram username.";
+  }
+  return null;
+}
+
+function validateFacebook(value: string): string | null {
+  const url = parseHttpUrl(value);
+  if (!url) return "Enter a valid Facebook profile URL.";
+  const host = stripWww(url.hostname);
+  if (!["facebook.com", "fb.com", "m.facebook.com"].includes(host)) {
+    return wrongHost("facebook");
+  }
+
+  const segments = pathSegments(url.pathname);
+  const blocked = new Set([
+    "groups",
+    "watch",
+    "events",
+    "marketplace",
+    "gaming",
+    "photo.php",
+    "story.php",
+    "share",
+  ]);
+  if (segments.length === 1 && !blocked.has(segments[0]!.toLowerCase())) {
+    if (/^[a-zA-Z0-9.]{1,50}$/.test(segments[0]!)) return null;
+  }
+  if (segments[0] === "profile.php" && url.searchParams.has("id")) return null;
+
+  return "Enter a Facebook profile or page URL (facebook.com/username).";
+}
+
+function validateLinkedin(value: string): string | null {
+  const url = parseHttpUrl(value);
+  if (!url) return "Enter a valid LinkedIn profile URL.";
+  if (stripWww(url.hostname) !== "linkedin.com") return wrongHost("linkedin");
+
+  const segments = pathSegments(url.pathname);
+  if (segments[0] === "in" && segments.length === 2 && /^[a-zA-Z0-9\-_%]+$/.test(segments[1]!)) {
+    return null;
+  }
+  return "Enter a LinkedIn profile URL (linkedin.com/in/username).";
+}
+
+function validateDiscord(value: string): string | null {
+  const trimmed = value.trim();
+  if (!/^https?:\/\//i.test(trimmed)) {
+    if (/^[\w.\-]{2,32}$/.test(trimmed)) return null;
+    return "Enter a Discord invite URL or username.";
+  }
+
+  const url = parseHttpUrl(trimmed);
+  if (!url) return "Enter a valid Discord invite URL or username.";
+
+  const host = stripWww(url.hostname);
+  if (host === "discord.gg") {
+    const code = pathSegments(url.pathname)[0];
+    if (code && /^[\w-]{2,32}$/.test(code)) return null;
+  }
+  if (host === "discord.com") {
+    const segments = pathSegments(url.pathname);
+    if (segments[0] === "invite" && segments[1] && /^[\w-]{2,32}$/.test(segments[1])) {
+      return null;
+    }
+    if (segments[0] === "users" && segments[1] && /^\d+$/.test(segments[1])) {
+      return null;
+    }
+  }
+  return "Enter a Discord invite (discord.gg/…) or username.";
+}
+
+function validateKofi(value: string): string | null {
+  const url = parseHttpUrl(value);
+  if (!url) return "Enter a valid Ko-fi profile URL.";
+  if (stripWww(url.hostname) !== "ko-fi.com") return wrongHost("kofi");
+
+  const segments = pathSegments(url.pathname);
+  if (segments.length === 1 && /^[a-zA-Z0-9_]{1,50}$/.test(segments[0]!)) return null;
+  return "Enter a Ko-fi page URL (ko-fi.com/username).";
+}
+
+function validatePatreon(value: string): string | null {
+  const url = parseHttpUrl(value);
+  if (!url) return "Enter a valid Patreon profile URL.";
+  if (stripWww(url.hostname) !== "patreon.com") return wrongHost("patreon");
+
+  const segments = pathSegments(url.pathname);
+  if (segments.length === 1 && !["posts", "membership", "checkout"].includes(segments[0]!)) {
+    if (/^[a-zA-Z0-9_]{1,50}$/.test(segments[0]!)) return null;
+  }
+  return "Enter a Patreon creator URL (patreon.com/username).";
+}
+
+function validateBluesky(value: string): string | null {
+  const url = parseHttpUrl(value);
+  if (!url) return "Enter a valid Bluesky profile URL.";
+  if (stripWww(url.hostname) !== "bsky.app") return wrongHost("bluesky");
+
+  const segments = pathSegments(url.pathname);
+  if (segments[0] === "profile" && segments.length === 2 && segments[1]!.length >= 3) {
+    return null;
+  }
+  return "Enter a Bluesky profile URL (bsky.app/profile/handle).";
+}
+
+function validateTwitter(value: string): string | null {
+  const url = parseHttpUrl(value);
+  if (!url) return "Enter a valid X profile URL.";
+  const host = stripWww(url.hostname);
+  if (!["x.com", "twitter.com"].includes(host)) return wrongHost("twitter");
+
+  const segments = pathSegments(url.pathname);
+  const blocked = new Set(["home", "search", "explore", "i", "intent", "share", "status"]);
+  if (segments.length === 1 && !blocked.has(segments[0]!.toLowerCase())) {
+    if (/^[a-zA-Z0-9_]{1,15}$/.test(segments[0]!)) return null;
+  }
+  return "Enter an X profile URL (x.com/username).";
+}
+
+function validateReddit(value: string): string | null {
+  const url = parseHttpUrl(value);
+  if (!url) return "Enter a valid Reddit profile URL.";
+  const host = stripWww(url.hostname);
+  if (!["reddit.com", "old.reddit.com"].includes(host)) return wrongHost("reddit");
+
+  const segments = pathSegments(url.pathname);
+  if (
+    (segments[0] === "u" || segments[0] === "user") &&
+    segments.length === 2 &&
+    /^[a-zA-Z0-9_-]{1,20}$/.test(segments[1]!)
+  ) {
+    return null;
+  }
+  return "Enter a Reddit profile URL (reddit.com/u/username).";
+}
+
+const VALIDATORS: Record<SocialPlatformId, (value: string) => string | null> = {
+  kick: validateKick,
+  youtube: validateYoutube,
+  twitch: validateTwitch,
+  instagram: validateInstagram,
+  facebook: validateFacebook,
+  linkedin: validateLinkedin,
+  discord: validateDiscord,
+  kofi: validateKofi,
+  patreon: validatePatreon,
+  bluesky: validateBluesky,
+  twitter: validateTwitter,
+  reddit: validateReddit,
+};
+
+/** Returns an error message, or null if the value is valid (empty is valid). */
+export function validateSocialLink(platformId: string, value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  if (!(SOCIAL_PLATFORM_IDS as readonly string[]).includes(platformId)) {
+    return "Unknown platform.";
+  }
+
+  return VALIDATORS[platformId as SocialPlatformId](trimmed);
+}
+
+/** Returns the first validation error across all links, or null if all are valid. */
+export function validateSocialLinks(links: Record<string, string>): string | null {
+  for (const [platformId, value] of Object.entries(links)) {
+    const err = validateSocialLink(platformId, value);
+    if (err) {
+      const label =
+        PLATFORM_LABELS[platformId as SocialPlatformId] ?? platformId;
+      return `${label}: ${err}`;
+    }
+  }
+  return null;
+}

--- a/packages/web/CLAUDE.md
+++ b/packages/web/CLAUDE.md
@@ -237,6 +237,31 @@ Four cookies hold session state (set/read/cleared in `src/lib/session.ts`, serve
 3. `app/auth/callback/page.tsx` (client component) parses the hash, stores the token in `sessionStorage` as `rs_recovery_token`, and redirects to `/auth/reset-password`
 4. `resetPasswordAction` reads the token from the form and calls `/api/v1/auth/reset-password`
 
+### Protecting routes
+
+Use `requireAuth(next?: string)` from `src/lib/session.ts` — never use middleware for this.
+
+**Protect an entire route subtree** — add a `layout.tsx` that calls `requireAuth`:
+```ts
+// app/(site)/settings/layout.tsx
+import { requireAuth } from "@/lib/session";
+
+export default async function SettingsLayout({ children }: { children: React.ReactNode }) {
+  await requireAuth("/settings");
+  return <>{children}</>;
+}
+```
+
+**Protect a single page** — call `requireAuth` at the top of the page function:
+```ts
+export default async function SomePage() {
+  const session = await requireAuth("/some/path");
+  // session is typed Session — use it if you need user data
+}
+```
+
+`requireAuth` redirects unauthenticated users to `/auth/login?next=<path>`. After login, `loginAction` reads `next` and redirects there. Do not use `proxy.ts` or middleware for auth gating — use this pattern.
+
 ### Supabase callback hash errors
 Supabase can redirect to the app root with errors in the URL hash (e.g. `/#error=access_denied&error_description=...`). Hash fragments are client-side only — the proxy cannot see them. The callback page (`app/auth/callback/page.tsx`) handles error hashes when Supabase redirects there, but errors landing on `/` are currently unhandled. **TODO:** add a client component on the root page to detect and surface these errors.
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -37,6 +37,7 @@
     "react-dom": "19.2.4",
     "react-hook-form": "^7.56.0",
     "shadcn": "^4.7.0",
+    "simple-icons": "^16.19.0",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
     "zod": "^4.4.3"

--- a/packages/web/src/app/(site)/settings/donations/page.tsx
+++ b/packages/web/src/app/(site)/settings/donations/page.tsx
@@ -1,0 +1,8 @@
+import type { Metadata } from "next";
+import { DonationsView } from "@/views/settings/donations-view";
+
+export const metadata: Metadata = { title: "Donations — Settings — Riftseer" };
+
+export default function DonationsPage() {
+  return <DonationsView />;
+}

--- a/packages/web/src/app/(site)/settings/donations/page.tsx
+++ b/packages/web/src/app/(site)/settings/donations/page.tsx
@@ -1,8 +1,13 @@
 import type { Metadata } from "next";
+import { getSession } from "@/lib/session";
+import { metafyApi } from "@/features/metafy/api";
 import { DonationsView } from "@/views/settings/donations-view";
 
 export const metadata: Metadata = { title: "Donations — Settings — Riftseer" };
 
-export default function DonationsPage() {
-  return <DonationsView />;
+export default async function DonationsPage() {
+  const session = await getSession();
+  const metafyStatus = session ? await metafyApi.getStatus(session.accessToken) : null;
+
+  return <DonationsView metafyStatus={metafyStatus} />;
 }

--- a/packages/web/src/app/(site)/settings/layout.tsx
+++ b/packages/web/src/app/(site)/settings/layout.tsx
@@ -1,0 +1,6 @@
+import { requireAuth } from "@/lib/session";
+
+export default async function SettingsLayout({ children }: { children: React.ReactNode }) {
+  await requireAuth("/settings");
+  return <>{children}</>;
+}

--- a/packages/web/src/app/(site)/settings/notifications/page.tsx
+++ b/packages/web/src/app/(site)/settings/notifications/page.tsx
@@ -1,0 +1,8 @@
+import type { Metadata } from "next";
+import { NotificationsView } from "@/views/settings/notifications-view";
+
+export const metadata: Metadata = { title: "Notifications — Settings — Riftseer" };
+
+export default function NotificationsPage() {
+  return <NotificationsView />;
+}

--- a/packages/web/src/app/(site)/settings/page.tsx
+++ b/packages/web/src/app/(site)/settings/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from "next";
+import { SettingsIndexView } from "@/views/settings/settings-index-view";
+
+export const metadata: Metadata = {
+  title: "Settings — Riftseer",
+};
+
+export default function SettingsPage() {
+  return <SettingsIndexView />;
+}

--- a/packages/web/src/app/(site)/settings/preferences/page.tsx
+++ b/packages/web/src/app/(site)/settings/preferences/page.tsx
@@ -1,0 +1,8 @@
+import type { Metadata } from "next";
+import { PreferencesView } from "@/views/settings/preferences-view";
+
+export const metadata: Metadata = { title: "User Preferences — Settings — Riftseer" };
+
+export default function PreferencesPage() {
+  return <PreferencesView />;
+}

--- a/packages/web/src/app/(site)/settings/profile/page.tsx
+++ b/packages/web/src/app/(site)/settings/profile/page.tsx
@@ -1,0 +1,8 @@
+import type { Metadata } from "next";
+import { ProfileSettingsView } from "@/views/settings/profile-settings-view";
+
+export const metadata: Metadata = { title: "User Profile — Settings — Riftseer" };
+
+export default function ProfileSettingsPage() {
+  return <ProfileSettingsView />;
+}

--- a/packages/web/src/app/(site)/settings/profile/page.tsx
+++ b/packages/web/src/app/(site)/settings/profile/page.tsx
@@ -1,8 +1,14 @@
 import type { Metadata } from "next";
+import { requireAuth } from "@/lib/session";
+import { getProfile } from "@/features/profile/api";
 import { ProfileSettingsView } from "@/views/settings/profile-settings-view";
 
 export const metadata: Metadata = { title: "User Profile — Settings — Riftseer" };
 
-export default function ProfileSettingsPage() {
-  return <ProfileSettingsView />;
+export default async function ProfileSettingsPage() {
+  const session = await requireAuth("/settings/profile");
+  const profile = session.user.handle
+    ? await getProfile(session.user.handle, session.accessToken)
+    : null;
+  return <ProfileSettingsView session={session} profile={profile} />;
 }

--- a/packages/web/src/app/(site)/settings/security/page.tsx
+++ b/packages/web/src/app/(site)/settings/security/page.tsx
@@ -1,0 +1,8 @@
+import type { Metadata } from "next";
+import { SecurityView } from "@/views/settings/security-view";
+
+export const metadata: Metadata = { title: "Login & Security — Settings — Riftseer" };
+
+export default function SecurityPage() {
+  return <SecurityView />;
+}

--- a/packages/web/src/app/(site)/settings/security/page.tsx
+++ b/packages/web/src/app/(site)/settings/security/page.tsx
@@ -1,8 +1,10 @@
 import type { Metadata } from "next";
+import { requireAuth } from "@/lib/session";
 import { SecurityView } from "@/views/settings/security-view";
 
 export const metadata: Metadata = { title: "Login & Security — Settings — Riftseer" };
 
-export default function SecurityPage() {
-  return <SecurityView />;
+export default async function SecurityPage() {
+  const session = await requireAuth("/settings/security");
+  return <SecurityView session={session} />;
 }

--- a/packages/web/src/app/(site)/u/[handle]/error.tsx
+++ b/packages/web/src/app/(site)/u/[handle]/error.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+
+export default function UserProfileError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("[user profile]", error);
+  }, [error]);
+
+  const isUnavailable = /503|unavailable/i.test(error.message ?? "");
+
+  return (
+    <div className="container flex flex-col gap-4 py-16 max-w-lg">
+      <h1 className="text-xl font-semibold">
+        {isUnavailable ? "Profile unavailable" : "Couldn't load this profile"}
+      </h1>
+      <p className="text-sm leading-relaxed text-muted-foreground">
+        {isUnavailable
+          ? "The service is temporarily unavailable. Please try again in a moment."
+          : "Something went wrong while loading this profile. Please try again."}
+      </p>
+      <Button variant="outline" className="w-fit" onClick={() => reset()}>
+        Try again
+      </Button>
+    </div>
+  );
+}

--- a/packages/web/src/app/(site)/u/[handle]/page.tsx
+++ b/packages/web/src/app/(site)/u/[handle]/page.tsx
@@ -1,0 +1,31 @@
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import { getProfile } from "@/features/profile/api";
+import { getSession } from "@/lib/session";
+import { ProfileView } from "@/views/profile/profile-view";
+
+interface Props {
+  params: Promise<{ handle: string }>;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { handle } = await params;
+  const profile = await getProfile(handle);
+  if (!profile) return { title: "User not found — Riftseer" };
+  return {
+    title: `${profile.username} (@${profile.handle}) — Riftseer`,
+    description: `${profile.username}'s profile on Riftseer.`,
+  };
+}
+
+export default async function UserProfilePage({ params }: Props) {
+  const { handle } = await params;
+  const session = await getSession();
+
+  const profile = await getProfile(handle, session?.accessToken);
+  if (!profile) notFound();
+
+  const isOwnProfile = session?.user.id === profile.id;
+
+  return <ProfileView profile={profile} isOwnProfile={isOwnProfile} />;
+}

--- a/packages/web/src/app/(site)/u/[handle]/page.tsx
+++ b/packages/web/src/app/(site)/u/[handle]/page.tsx
@@ -27,5 +27,11 @@ export default async function UserProfilePage({ params }: Props) {
 
   const isOwnProfile = session?.user.id === profile.id;
 
-  return <ProfileView profile={profile} isOwnProfile={isOwnProfile} />;
+  return (
+    <ProfileView
+      profile={profile}
+      isOwnProfile={isOwnProfile}
+      isLoggedIn={session !== null}
+    />
+  );
 }

--- a/packages/web/src/app/auth/metafy/callback/page.tsx
+++ b/packages/web/src/app/auth/metafy/callback/page.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { completeMetafyCallbackAction } from "@/features/metafy/actions";
+
+type State =
+  | { status: "loading" }
+  | { status: "success" }
+  | { status: "error"; message: string };
+
+export default function MetafyCallbackPage() {
+  const router = useRouter();
+  const [state, setState] = useState<State>({ status: "loading" });
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get("code");
+    const state = params.get("state");
+    const error = params.get("error");
+    const errorDescription = params.get("error_description");
+
+    if (error || errorDescription) {
+      setState({
+        status: "error",
+        message: errorDescription ?? error ?? "Metafy authorization was denied.",
+      });
+      return;
+    }
+
+    if (!code || !state) {
+      setState({ status: "error", message: "Missing OAuth parameters. Please try again." });
+      return;
+    }
+
+    completeMetafyCallbackAction(code, state).then((result) => {
+      if ("error" in result) {
+        setState({ status: "error", message: result.error });
+      } else {
+        setState({ status: "success" });
+        setTimeout(() => router.replace("/settings/donations?linked=1"), 1000);
+      }
+    });
+  }, [router]);
+
+  if (state.status === "loading") {
+    return <p className="text-sm text-muted-foreground">Linking your Metafy account…</p>;
+  }
+
+  if (state.status === "success") {
+    return (
+      <div className="text-center space-y-2">
+        <p className="font-medium">Metafy account linked!</p>
+        <p className="text-sm text-muted-foreground">Redirecting…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="text-center space-y-2">
+      <p className="font-medium text-destructive">Something went wrong</p>
+      <p className="text-sm text-muted-foreground">{state.message}</p>
+      <p className="text-sm">
+        <Link href="/settings/donations" className="underline underline-offset-4">
+          Back to donations settings
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/packages/web/src/components/layout/navbar.tsx
+++ b/packages/web/src/components/layout/navbar.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { Backpack } from "lucide-react";
 import { getSession } from "@/lib/session";
+import { metafyApi } from "@/features/metafy/api";
 import { UserNav } from "./user-nav";
 import { CardSearchTrigger } from "./card-search-trigger";
 import { Button } from "@/components/ui/button";
@@ -8,6 +9,14 @@ import { CardsNavMenu } from "./cards-nav-menu";
 
 export async function Navbar() {
   const session = await getSession();
+
+  let isSupporter = false;
+  let isMember = false;
+  if (session) {
+    const metafy = await metafyApi.getStatus(session.accessToken);
+    isSupporter = metafy?.linked === true && metafy.is_supporter;
+    isMember = metafy?.linked === true && metafy.is_member;
+  }
 
   return (
     <header className="border-b border-border">
@@ -30,7 +39,7 @@ export async function Navbar() {
             </Link>
           </Button>
           {session ? (
-            <UserNav handle={session.user.handle} />
+            <UserNav handle={session.user.handle} isSupporter={isSupporter} isMember={isMember} />
           ) : (
             <>
               <Button variant="ghost" size="sm" asChild>

--- a/packages/web/src/components/layout/navbar.tsx
+++ b/packages/web/src/components/layout/navbar.tsx
@@ -30,7 +30,7 @@ export async function Navbar() {
             </Link>
           </Button>
           {session ? (
-            <UserNav email={session.user.email} />
+            <UserNav handle={session.user.handle} />
           ) : (
             <>
               <Button variant="ghost" size="sm" asChild>

--- a/packages/web/src/components/layout/user-nav.tsx
+++ b/packages/web/src/components/layout/user-nav.tsx
@@ -28,13 +28,14 @@ export function UserNav({ handle }: UserNavProps) {
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
         {handle && (
-          <>
-            <DropdownMenuItem asChild>
-              <Link href={`/u/${handle}`}>Profile</Link>
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-          </>
+          <DropdownMenuItem asChild>
+            <Link href={`/u/${handle}`}>Profile</Link>
+          </DropdownMenuItem>
         )}
+        <DropdownMenuItem asChild>
+          <Link href="/settings">Settings</Link>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
         <DropdownMenuItem
           onSelect={() => startTransition(() => logoutAction())}
           disabled={pending}

--- a/packages/web/src/components/layout/user-nav.tsx
+++ b/packages/web/src/components/layout/user-nav.tsx
@@ -1,30 +1,40 @@
 "use client";
 
 import { useTransition } from "react";
+import Link from "next/link";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
 import { logoutAction } from "@/features/auth/actions";
 
 interface UserNavProps {
-  email?: string;
+  handle?: string;
 }
 
-export function UserNav({ email }: UserNavProps) {
+export function UserNav({ handle }: UserNavProps) {
   const [pending, startTransition] = useTransition();
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button variant="ghost" size="sm">
-          {email ?? "Account"}
+          {handle ? `@${handle}` : "Account"}
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
+        {handle && (
+          <>
+            <DropdownMenuItem asChild>
+              <Link href={`/u/${handle}`}>Profile</Link>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+          </>
+        )}
         <DropdownMenuItem
           onSelect={() => startTransition(() => logoutAction())}
           disabled={pending}

--- a/packages/web/src/components/layout/user-nav.tsx
+++ b/packages/web/src/components/layout/user-nav.tsx
@@ -2,6 +2,7 @@
 
 import { useTransition } from "react";
 import Link from "next/link";
+import { Star, Users } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -14,15 +15,19 @@ import { logoutAction } from "@/features/auth/actions";
 
 interface UserNavProps {
   handle?: string;
+  isSupporter?: boolean;
+  isMember?: boolean;
 }
 
-export function UserNav({ handle }: UserNavProps) {
+export function UserNav({ handle, isSupporter, isMember }: UserNavProps) {
   const [pending, startTransition] = useTransition();
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="sm">
+        <Button variant="ghost" size="sm" className="gap-1.5">
+          {isSupporter && <Star className="size-3 fill-violet-500 text-violet-500" />}
+          {!isSupporter && isMember && <Users className="size-3 text-blue-500" />}
           {handle ? `@${handle}` : "Account"}
         </Button>
       </DropdownMenuTrigger>

--- a/packages/web/src/components/metafy/metafy-account-panel.tsx
+++ b/packages/web/src/components/metafy/metafy-account-panel.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useSearchParams } from "next/navigation";
+import { CheckCircle2, Star, Users } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  connectMetafyAction,
+  disconnectMetafyAction,
+  refreshMetafyStatusAction,
+} from "@/features/metafy/actions";
+import type { MetafyStatusResult } from "@/features/metafy/types";
+
+interface MetafyAccountPanelProps {
+  initialStatus: MetafyStatusResult | null;
+}
+
+export function MetafyAccountPanel({ initialStatus }: MetafyAccountPanelProps) {
+  const searchParams = useSearchParams();
+  const justLinked = searchParams.get("linked") === "1";
+  const justErrored = searchParams.get("error") === "1";
+
+  const [status, setStatus] = useState<MetafyStatusResult | null>(initialStatus);
+  const [feedback, setFeedback] = useState<string | null>(
+    justLinked ? "Metafy account linked!" : justErrored ? "Failed to link Metafy account. Please try again." : null,
+  );
+  const [connectPending, startConnect] = useTransition();
+  const [disconnectPending, startDisconnect] = useTransition();
+  const [refreshPending, startRefresh] = useTransition();
+
+  function handleConnect() {
+    startConnect(async () => {
+      const result = await connectMetafyAction();
+      if ("error" in result) setFeedback(result.error);
+      // On success, connectMetafyAction redirects — no further state update needed
+    });
+  }
+
+  function handleDisconnect() {
+    startDisconnect(async () => {
+      const result = await disconnectMetafyAction();
+      if ("error" in result) {
+        setFeedback(result.error);
+      } else {
+        setStatus({ linked: false });
+        setFeedback("Metafy account unlinked.");
+      }
+    });
+  }
+
+  function handleRefresh() {
+    startRefresh(async () => {
+      const result = await refreshMetafyStatusAction();
+      if ("error" in result) {
+        setFeedback(result.error);
+      } else {
+        setStatus((prev) =>
+          prev?.linked
+            ? { ...prev, is_supporter: result.is_supporter }
+            : prev,
+        );
+        setFeedback(
+          result.is_supporter
+            ? "You are an active Metafy supporter."
+            : "Supporter status updated — no active membership found.",
+        );
+      }
+    });
+  }
+
+  if (!status?.linked) {
+    return (
+      <div className="flex flex-col items-end gap-1.5">
+        <Button
+          size="sm"
+          onClick={handleConnect}
+          disabled={connectPending}
+        >
+          {connectPending ? "Redirecting…" : "Link Metafy Account"}
+        </Button>
+        {feedback && (
+          <p className="text-xs text-muted-foreground">{feedback}</p>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-1.5">
+      <div className="flex items-center gap-2">
+        <span className="flex items-center gap-1 text-xs font-medium text-green-600">
+          <CheckCircle2 className="size-3" />
+          Connected
+        </span>
+        {status.is_supporter && (
+          <span className="flex items-center gap-1 text-xs font-medium text-violet-500">
+            <Star className="size-3 fill-current" />
+            Supporter
+          </span>
+        )}
+        {!status.is_supporter && status.is_member && (
+          <span className="flex items-center gap-1 text-xs font-medium text-blue-500">
+            <Users className="size-3" />
+            Member
+          </span>
+        )}
+        {status.provider_username && (
+          <span className="text-sm text-muted-foreground">@{status.provider_username}</span>
+        )}
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={handleRefresh}
+          disabled={refreshPending || disconnectPending}
+        >
+          {refreshPending ? "Checking…" : "Refresh"}
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={handleDisconnect}
+          disabled={disconnectPending || refreshPending}
+        >
+          {disconnectPending ? "Unlinking…" : "Unlink"}
+        </Button>
+      </div>
+      {feedback && (
+        <p className="text-xs text-muted-foreground">{feedback}</p>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/profile/follow-button.tsx
+++ b/packages/web/src/components/profile/follow-button.tsx
@@ -1,20 +1,34 @@
 "use client";
 
 import { useTransition, useState } from "react";
+import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { followAction, unfollowAction } from "@/features/profile/actions";
 
 interface FollowButtonProps {
   handle: string;
   initialIsFollowing: boolean;
+  isLoggedIn: boolean;
   onCountChange?: (delta: number) => void;
 }
 
-export function FollowButton({ handle, initialIsFollowing, onCountChange }: FollowButtonProps) {
+export function FollowButton({
+  handle,
+  initialIsFollowing,
+  isLoggedIn,
+  onCountChange,
+}: FollowButtonProps) {
+  const router = useRouter();
   const [isFollowing, setIsFollowing] = useState(initialIsFollowing);
   const [pending, startTransition] = useTransition();
 
   function toggle() {
+    if (!isLoggedIn) {
+      const next = encodeURIComponent(`/u/${handle}`);
+      router.push(`/auth/login?next=${next}`);
+      return;
+    }
+
     startTransition(async () => {
       if (isFollowing) {
         const result = await unfollowAction(handle);

--- a/packages/web/src/components/profile/follow-button.tsx
+++ b/packages/web/src/components/profile/follow-button.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useTransition, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { followAction, unfollowAction } from "@/features/profile/actions";
+
+interface FollowButtonProps {
+  handle: string;
+  initialIsFollowing: boolean;
+  onCountChange?: (delta: number) => void;
+}
+
+export function FollowButton({ handle, initialIsFollowing, onCountChange }: FollowButtonProps) {
+  const [isFollowing, setIsFollowing] = useState(initialIsFollowing);
+  const [pending, startTransition] = useTransition();
+
+  function toggle() {
+    startTransition(async () => {
+      if (isFollowing) {
+        const result = await unfollowAction(handle);
+        if (!result.error) {
+          setIsFollowing(false);
+          onCountChange?.(-1);
+        }
+      } else {
+        const result = await followAction(handle);
+        if (!result.error) {
+          setIsFollowing(true);
+          onCountChange?.(1);
+        }
+      }
+    });
+  }
+
+  return (
+    <Button
+      variant={isFollowing ? "outline" : "default"}
+      size="sm"
+      onClick={toggle}
+      disabled={pending}
+    >
+      {isFollowing ? "Unfollow" : "Follow"}
+    </Button>
+  );
+}

--- a/packages/web/src/components/ui/social-icon.tsx
+++ b/packages/web/src/components/ui/social-icon.tsx
@@ -1,0 +1,21 @@
+import { cn } from "@/lib/utils";
+
+interface SocialIconProps {
+  svgPath: string;
+  className?: string;
+  "aria-label"?: string;
+}
+
+export function SocialIcon({ svgPath, className, "aria-label": ariaLabel }: SocialIconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={cn("shrink-0", className)}
+      aria-label={ariaLabel}
+      aria-hidden={ariaLabel ? undefined : true}
+    >
+      <path d={svgPath} />
+    </svg>
+  );
+}

--- a/packages/web/src/features/auth/actions.ts
+++ b/packages/web/src/features/auth/actions.ts
@@ -39,7 +39,11 @@ export async function loginAction(_prev: unknown, formData: FormData) {
 export async function registerAction(_prev: unknown, formData: FormData) {
   const email = str(formData, "email");
   const password = str(formData, "password");
+  const username = str(formData, "username");
+  const handle = str(formData, "handle")?.toLowerCase() ?? null;
   if (!email || !password) return { error: "Email and password are required" };
+  if (!username) return { error: "Display name is required" };
+  if (!handle) return { error: "Handle is required" };
 
   const acceptedRaw = formData.get("accepted_terms");
   const acceptedTerms = acceptedRaw === "on" || acceptedRaw === "true";
@@ -54,11 +58,16 @@ export async function registerAction(_prev: unknown, formData: FormData) {
   const { data, error, status } = await api.api.v1.auth.register.post({
     email,
     password,
+    username,
+    handle,
     accepted_terms: true,
     options: { redirect_to: `${env.NEXT_PUBLIC_APP_URL}/auth/callback` },
   });
 
   if (error) {
+    if (status === 409) {
+      return { error: "That handle is already taken. Please choose another." };
+    }
     return { error: (error.value as { error?: string })?.error ?? "Registration failed" };
   }
 
@@ -70,7 +79,7 @@ export async function registerAction(_prev: unknown, formData: FormData) {
     access_token: string;
     refresh_token: string;
     expires_in: number;
-    user: { id: string; email?: string; created_at: string };
+    user: { id: string; email?: string; created_at: string; handle?: string; username?: string };
   };
 
   await setSessionCookies({

--- a/packages/web/src/features/auth/actions.ts
+++ b/packages/web/src/features/auth/actions.ts
@@ -124,6 +124,86 @@ export async function forgotPasswordAction(_prev: unknown, formData: FormData) {
   return { ok: true };
 }
 
+export async function changeEmailAction(_prev: unknown, formData: FormData) {
+  const email = str(formData, "email");
+  if (!email) return { error: "Email is required" };
+
+  const session = await getSession();
+  if (!session) return { error: "Not signed in" };
+
+  const res = await fetch(`${env.NEXT_PUBLIC_API_URL}/api/v1/auth/email`, {
+    method: "PATCH",
+    headers: {
+      Authorization: `Bearer ${session.accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ email }),
+  });
+
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    return { error: body.error ?? "Email update failed" };
+  }
+
+  return { ok: true };
+}
+
+export async function changePasswordAction(_prev: unknown, formData: FormData) {
+  const currentPassword = str(formData, "current_password");
+  const newPassword = str(formData, "new_password");
+  const confirmPassword = str(formData, "confirm_password");
+
+  if (!currentPassword) return { error: "Current password is required" };
+  if (!newPassword) return { error: "New password is required" };
+  if (newPassword.length < 8) return { error: "New password must be at least 8 characters" };
+  if (newPassword !== confirmPassword) return { error: "Passwords do not match" };
+
+  const session = await getSession();
+  if (!session) return { error: "Not signed in" };
+
+  const res = await fetch(`${env.NEXT_PUBLIC_API_URL}/api/v1/auth/change-password`, {
+    method: "PATCH",
+    headers: {
+      Authorization: `Bearer ${session.accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ current_password: currentPassword, new_password: newPassword }),
+  });
+
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    return { error: body.error ?? "Password change failed" };
+  }
+
+  return { ok: true };
+}
+
+export async function deleteAccountAction(_prev: unknown, formData: FormData) {
+  const confirmation = str(formData, "confirmation");
+  if (!confirmation) return { error: "Confirmation is required" };
+
+  const session = await getSession();
+  if (!session) return { error: "Not signed in" };
+
+  const expectedHandle = session.user.handle ?? "";
+  if (confirmation.toLowerCase() !== expectedHandle.toLowerCase()) {
+    return { error: `Type your @handle (${expectedHandle}) exactly to confirm deletion` };
+  }
+
+  const res = await fetch(`${env.NEXT_PUBLIC_API_URL}/api/v1/users/me`, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${session.accessToken}` },
+  });
+
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    return { error: body.error ?? "Account deletion failed" };
+  }
+
+  await clearSessionCookies();
+  redirect("/");
+}
+
 export async function resetPasswordAction(_prev: unknown, formData: FormData) {
   const password = str(formData, "password");
   const recoveryToken = str(formData, "recovery_token");

--- a/packages/web/src/features/auth/types.ts
+++ b/packages/web/src/features/auth/types.ts
@@ -2,6 +2,8 @@ export interface SessionUser {
   id: string;
   email?: string;
   created_at: string;
+  handle?: string;
+  username?: string;
 }
 
 export interface Session {

--- a/packages/web/src/features/metafy/actions.ts
+++ b/packages/web/src/features/metafy/actions.ts
@@ -1,0 +1,106 @@
+"use server";
+
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/session";
+import { env } from "@/lib/env";
+
+const STATE_COOKIE = "rs_metafy_oauth_state";
+
+export async function connectMetafyAction(): Promise<{ error: string }> {
+  const session = await getSession();
+  if (!session) return { error: "Not signed in" };
+
+  const res = await fetch(`${env.NEXT_PUBLIC_API_URL}/api/v1/auth/metafy/connect`, {
+    headers: { Authorization: `Bearer ${session.accessToken}` },
+  });
+
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    return { error: body.error ?? "Failed to initiate Metafy connection" };
+  }
+
+  const { url, state } = (await res.json()) as { url: string; state: string };
+
+  const jar = await cookies();
+  jar.set(STATE_COOKIE, state, {
+    path: "/",
+    httpOnly: true,
+    sameSite: "lax",
+    secure: env.NODE_ENV === "production",
+    maxAge: 60 * 10,
+  });
+
+  redirect(url);
+}
+
+export async function completeMetafyCallbackAction(
+  code: string,
+  state: string,
+): Promise<{ error: string } | { ok: true }> {
+  const session = await getSession();
+  if (!session) return { error: "Not signed in" };
+
+  const jar = await cookies();
+  const savedState = jar.get(STATE_COOKIE)?.value;
+
+  if (!savedState || savedState !== state) {
+    return { error: "Invalid or expired OAuth state. Please try linking again." };
+  }
+
+  jar.delete(STATE_COOKIE);
+
+  const res = await fetch(`${env.NEXT_PUBLIC_API_URL}/api/v1/auth/metafy/callback`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${session.accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ code, state }),
+  });
+
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    return { error: body.error ?? "Failed to link Metafy account" };
+  }
+
+  return { ok: true };
+}
+
+export async function disconnectMetafyAction(): Promise<{ error: string } | { ok: true }> {
+  const session = await getSession();
+  if (!session) return { error: "Not signed in" };
+
+  const res = await fetch(`${env.NEXT_PUBLIC_API_URL}/api/v1/auth/metafy/disconnect`, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${session.accessToken}` },
+  });
+
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    return { error: body.error ?? "Failed to disconnect Metafy account" };
+  }
+
+  return { ok: true };
+}
+
+export async function refreshMetafyStatusAction(): Promise<
+  { error: string } | { ok: true; is_supporter: boolean }
+> {
+  const session = await getSession();
+  if (!session) return { error: "Not signed in" };
+
+  const res = await fetch(`${env.NEXT_PUBLIC_API_URL}/api/v1/auth/metafy/refresh-status`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${session.accessToken}` },
+  });
+
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    if (res.status === 404) return { error: "No linked Metafy account" };
+    return { error: body.error ?? "Failed to refresh supporter status" };
+  }
+
+  const data = (await res.json()) as { is_supporter: boolean };
+  return { ok: true, is_supporter: data.is_supporter };
+}

--- a/packages/web/src/features/metafy/api.ts
+++ b/packages/web/src/features/metafy/api.ts
@@ -1,0 +1,17 @@
+import { env } from "@/lib/env";
+import type { MetafyStatusResult } from "./types";
+
+export const metafyApi = {
+  async getStatus(accessToken: string): Promise<MetafyStatusResult | null> {
+    try {
+      const res = await fetch(`${env.NEXT_PUBLIC_API_URL}/api/v1/auth/metafy/status`, {
+        headers: { Authorization: `Bearer ${accessToken}` },
+        next: { revalidate: 300 },
+      });
+      if (!res.ok) return null;
+      return res.json() as Promise<MetafyStatusResult>;
+    } catch {
+      return null;
+    }
+  },
+};

--- a/packages/web/src/features/metafy/types.ts
+++ b/packages/web/src/features/metafy/types.ts
@@ -1,0 +1,12 @@
+export interface LinkedMetafyAccount {
+  provider: string;
+  provider_username: string | null;
+  is_supporter: boolean;
+  is_member: boolean;
+  linked_at: string;
+  status_checked_at: string | null;
+}
+
+export type MetafyStatusResult =
+  | { linked: false }
+  | ({ linked: true } & LinkedMetafyAccount);

--- a/packages/web/src/features/profile/actions.ts
+++ b/packages/web/src/features/profile/actions.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { getSession } from "@/lib/session";
+import { getSession, updateSessionUser } from "@/lib/session";
 import { env } from "@/lib/env";
 
 async function fetchFollow(handle: string, method: "POST" | "DELETE") {
@@ -31,4 +31,72 @@ export async function followAction(handle: string) {
 
 export async function unfollowAction(handle: string) {
   return fetchFollow(handle, "DELETE");
+}
+
+export async function updateProfileAction(data: {
+  username?: string;
+  bio?: string;
+  pronouns?: string[];
+  social_links?: Record<string, string>;
+}) {
+  const session = await getSession();
+  if (!session) return { error: "Not signed in" };
+
+  const res = await fetch(`${env.NEXT_PUBLIC_API_URL}/api/v1/users/me`, {
+    method: "PATCH",
+    headers: {
+      Authorization: `Bearer ${session.accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  });
+
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    return { error: body.error ?? "Failed to update profile" };
+  }
+
+  const result = (await res.json()) as { message: string; username?: string };
+
+  if (result.username) {
+    await updateSessionUser({ username: result.username });
+  }
+
+  if (session.user.handle) {
+    revalidatePath(`/u/${session.user.handle}`);
+  }
+
+  return { ok: true };
+}
+
+export async function updateHandleAction(handle: string) {
+  const session = await getSession();
+  if (!session) return { error: "Not signed in" };
+
+  const res = await fetch(`${env.NEXT_PUBLIC_API_URL}/api/v1/users/me`, {
+    method: "PATCH",
+    headers: {
+      Authorization: `Bearer ${session.accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ handle }),
+  });
+
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    return { error: body.error ?? "Failed to update handle" };
+  }
+
+  const result = (await res.json()) as { message: string; handle?: string };
+  const newHandle = result.handle ?? handle;
+
+  if (session.user.handle) {
+    revalidatePath(`/u/${session.user.handle}`);
+  }
+  revalidatePath(`/u/${newHandle}`);
+  revalidatePath("/settings/profile");
+
+  await updateSessionUser({ handle: newHandle });
+
+  return { ok: true, handle: newHandle };
 }

--- a/packages/web/src/features/profile/actions.ts
+++ b/packages/web/src/features/profile/actions.ts
@@ -1,0 +1,34 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { getSession } from "@/lib/session";
+import { env } from "@/lib/env";
+
+async function fetchFollow(handle: string, method: "POST" | "DELETE") {
+  const session = await getSession();
+  if (!session) return { error: "Not signed in" };
+
+  const res = await fetch(
+    `${env.NEXT_PUBLIC_API_URL}/api/v1/users/${encodeURIComponent(handle)}/follow`,
+    {
+      method,
+      headers: { Authorization: `Bearer ${session.accessToken}` },
+    },
+  );
+
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    return { error: body.error ?? "Request failed" };
+  }
+
+  revalidatePath(`/u/${handle}`);
+  return { ok: true };
+}
+
+export async function followAction(handle: string) {
+  return fetchFollow(handle, "POST");
+}
+
+export async function unfollowAction(handle: string) {
+  return fetchFollow(handle, "DELETE");
+}

--- a/packages/web/src/features/profile/api.ts
+++ b/packages/web/src/features/profile/api.ts
@@ -1,0 +1,26 @@
+import { env } from "@/lib/env";
+
+export interface ProfileData {
+  id: string;
+  handle: string;
+  username: string;
+  follower_count: number;
+  following_count: number;
+  created_at: string;
+  is_following?: boolean;
+}
+
+export async function getProfile(handle: string, accessToken?: string): Promise<ProfileData | null> {
+  const headers: Record<string, string> = {};
+  if (accessToken) headers["Authorization"] = `Bearer ${accessToken}`;
+
+  const res = await fetch(`${env.NEXT_PUBLIC_API_URL}/api/v1/users/${encodeURIComponent(handle)}`, {
+    headers,
+    cache: "no-store",
+  });
+
+  if (res.status === 404) return null;
+  if (!res.ok) return null;
+
+  return res.json() as Promise<ProfileData>;
+}

--- a/packages/web/src/features/profile/api.ts
+++ b/packages/web/src/features/profile/api.ts
@@ -8,6 +8,8 @@ export interface ProfileData {
   following_count: number;
   created_at: string;
   is_following?: boolean;
+  is_supporter: boolean;
+  is_member: boolean;
 }
 
 export async function getProfile(handle: string, accessToken?: string): Promise<ProfileData | null> {

--- a/packages/web/src/features/profile/api.ts
+++ b/packages/web/src/features/profile/api.ts
@@ -4,6 +4,9 @@ export interface ProfileData {
   id: string;
   handle: string;
   username: string;
+  bio: string | null;
+  pronouns: string[];
+  social_links: Record<string, string>;
   follower_count: number;
   following_count: number;
   created_at: string;
@@ -22,7 +25,7 @@ export async function getProfile(handle: string, accessToken?: string): Promise<
   });
 
   if (res.status === 404) return null;
-  if (!res.ok) return null;
+  if (!res.ok) throw new Error(`Failed to load profile: ${res.status}`);
 
   return res.json() as Promise<ProfileData>;
 }

--- a/packages/web/src/lib/session.ts
+++ b/packages/web/src/lib/session.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
 import type { Session, SessionUser } from "@/features/auth/types";
 import { env } from "@/lib/env";
 
@@ -51,6 +52,15 @@ export async function setSessionCookies(session: {
     }),
     { ...COOKIE_OPTS, httpOnly: true, maxAge: REFRESH_MAX_AGE },
   );
+}
+
+export async function requireAuth(next?: string): Promise<Session> {
+  const session = await getSession();
+  if (!session) {
+    const params = next ? `?next=${encodeURIComponent(next)}` : "";
+    redirect(`/auth/login${params}`);
+  }
+  return session;
 }
 
 export async function clearSessionCookies() {

--- a/packages/web/src/lib/session.ts
+++ b/packages/web/src/lib/session.ts
@@ -63,6 +63,22 @@ export async function requireAuth(next?: string): Promise<Session> {
   return session;
 }
 
+export async function updateSessionUser(updates: Partial<SessionUser>) {
+  const jar = await cookies();
+  const userRaw = jar.get("rs_user")?.value;
+  if (!userRaw) return;
+  try {
+    const current = JSON.parse(userRaw) as SessionUser;
+    jar.set(
+      "rs_user",
+      JSON.stringify({ ...current, ...updates }),
+      { ...COOKIE_OPTS, httpOnly: true, maxAge: REFRESH_MAX_AGE },
+    );
+  } catch {
+    // ignore — session will refresh naturally
+  }
+}
+
 export async function clearSessionCookies() {
   const jar = await cookies();
   jar.delete("rs_access_token");

--- a/packages/web/src/lib/session.ts
+++ b/packages/web/src/lib/session.ts
@@ -41,11 +41,16 @@ export async function setSessionCookies(session: {
   jar.set("rs_access_token", session.access_token, { ...COOKIE_OPTS, httpOnly: true, maxAge: ACCESS_MAX_AGE });
   jar.set("rs_refresh_token", session.refresh_token, { ...COOKIE_OPTS, httpOnly: true, maxAge: REFRESH_MAX_AGE });
   jar.set("rs_expires_at", String(expiresAt), { ...COOKIE_OPTS, httpOnly: false, maxAge: REFRESH_MAX_AGE });
-  jar.set("rs_user", JSON.stringify({ id: session.user.id, email: session.user.email }), {
-    ...COOKIE_OPTS,
-    httpOnly: true,
-    maxAge: REFRESH_MAX_AGE,
-  });
+  jar.set(
+    "rs_user",
+    JSON.stringify({
+      id: session.user.id,
+      email: session.user.email,
+      handle: session.user.handle,
+      username: session.user.username,
+    }),
+    { ...COOKIE_OPTS, httpOnly: true, maxAge: REFRESH_MAX_AGE },
+  );
 }
 
 export async function clearSessionCookies() {

--- a/packages/web/src/lib/social-platforms.ts
+++ b/packages/web/src/lib/social-platforms.ts
@@ -1,0 +1,105 @@
+import {
+  siBluesky,
+  siDiscord,
+  siFacebook,
+  siInstagram,
+  siKick,
+  siKofi,
+  siPatreon,
+  siReddit,
+  siTwitch,
+  siX,
+  siYoutube,
+} from "simple-icons";
+
+// LinkedIn SVG path inlined — LinkedIn removed their icon from Simple Icons (disallows reproduction).
+// Path sourced from the official LinkedIn brand guidelines (viewBox 0 0 24 24).
+const LINKEDIN_PATH =
+  "M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z";
+
+export interface SocialPlatform {
+  id: string;
+  label: string;
+  /** SVG path data — viewBox "0 0 24 24", fill currentColor */
+  svgPath: string;
+  placeholder: string;
+}
+
+/**
+ * Ordered list of supported social platforms.
+ * To add a new platform: import its icon from simple-icons and append an entry here.
+ */
+export const SOCIAL_PLATFORMS: SocialPlatform[] = [
+  {
+    id: "kick",
+    label: "Kick",
+    svgPath: siKick.path,
+    placeholder: "https://kick.com/username",
+  },
+  {
+    id: "youtube",
+    label: "YouTube",
+    svgPath: siYoutube.path,
+    placeholder: "https://youtube.com/@channel",
+  },
+  {
+    id: "twitch",
+    label: "Twitch",
+    svgPath: siTwitch.path,
+    placeholder: "https://twitch.tv/username",
+  },
+  {
+    id: "instagram",
+    label: "Instagram",
+    svgPath: siInstagram.path,
+    placeholder: "https://instagram.com/username",
+  },
+  {
+    id: "facebook",
+    label: "Facebook",
+    svgPath: siFacebook.path,
+    placeholder: "https://facebook.com/username",
+  },
+  {
+    id: "linkedin",
+    label: "LinkedIn",
+    svgPath: LINKEDIN_PATH,
+    placeholder: "https://linkedin.com/in/username",
+  },
+  {
+    id: "discord",
+    label: "Discord",
+    svgPath: siDiscord.path,
+    placeholder: "https://discord.gg/invite or username",
+  },
+  {
+    id: "kofi",
+    label: "Ko-fi",
+    svgPath: siKofi.path,
+    placeholder: "https://ko-fi.com/username",
+  },
+  {
+    id: "patreon",
+    label: "Patreon",
+    svgPath: siPatreon.path,
+    placeholder: "https://patreon.com/username",
+  },
+  {
+    id: "bluesky",
+    label: "Bluesky",
+    svgPath: siBluesky.path,
+    placeholder: "https://bsky.app/profile/handle",
+  },
+  {
+    id: "twitter",
+    label: "X / Twitter",
+    svgPath: siX.path,
+    placeholder: "https://x.com/username",
+  },
+  {
+    id: "reddit",
+    label: "Reddit",
+    svgPath: siReddit.path,
+    placeholder: "https://reddit.com/u/username",
+  },
+];

--- a/packages/web/src/views/auth/register-view.tsx
+++ b/packages/web/src/views/auth/register-view.tsx
@@ -13,6 +13,13 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import { registerAction } from "@/features/auth/actions";
 
 const schema = z.object({
+  username: z.string().min(1, { message: "Display name is required" }).max(50),
+  handle: z
+    .string()
+    .min(3, { message: "Handle must be at least 3 characters" })
+    .max(30, { message: "Handle must be 30 characters or fewer" })
+    .regex(/^[a-z0-9_]+$/, { message: "Only lowercase letters, numbers, and underscores" })
+    .transform((v) => v.toLowerCase()),
   email: z.string().email({ message: "Enter a valid email" }),
   password: z.string().min(8, { message: "Password must be at least 8 characters" }),
 });
@@ -77,6 +84,37 @@ export function RegisterView() {
               </Link>
               .
             </label>
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="username">Display name</Label>
+            <Input
+              id="username"
+              type="text"
+              autoComplete="name"
+              aria-invalid={!!errors.username}
+              {...register("username")}
+            />
+            {errors.username && <p className="text-xs text-destructive">{errors.username.message}</p>}
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="handle">Username</Label>
+            <div className="relative">
+              <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-muted-foreground text-sm select-none">
+                @
+              </span>
+              <Input
+                id="handle"
+                type="text"
+                autoComplete="username"
+                className="pl-7"
+                aria-invalid={!!errors.handle}
+                {...register("handle")}
+              />
+            </div>
+            {errors.handle
+              ? <p className="text-xs text-destructive">{errors.handle.message}</p>
+              : <p className="text-xs text-muted-foreground">Your unique handle — letters, numbers, underscores</p>
+            }
           </div>
           <div className="space-y-1">
             <Label htmlFor="email">Email</Label>

--- a/packages/web/src/views/privacy-view.tsx
+++ b/packages/web/src/views/privacy-view.tsx
@@ -9,7 +9,7 @@ export function PrivacyView() {
           <h1 className="text-4xl font-bold tracking-tight text-foreground">Privacy Policy</h1>
         </div>
 
-        <p className="mb-6 text-sm text-muted-foreground">Last updated: 10 May 2026</p>
+        <p className="mb-6 text-sm text-muted-foreground">Last updated: 15 May 2026</p>
 
         <div className="mb-6">
           <SubHeading>Introduction</SubHeading>
@@ -94,6 +94,23 @@ export function PrivacyView() {
               We do not use this data for advertising.
             </ListItem>
           </UnorderedList>
+        </div>
+
+        <div className="mb-6">
+          <SubHeading>Metafy account linking</SubHeading>
+          <Text>
+            If you choose to link your Metafy account, we store the following in our database
+            server-side: your Metafy username, your Metafy user identifier, your OAuth access
+            token (and refresh token, if issued), and your supporter status. This data is used
+            exclusively to verify your Metafy membership and to enable supporter perks (ad-free
+            experience and supporter badge). Your Metafy OAuth tokens are never exposed to the
+            browser; they remain server-side and are used only to re-check your membership status
+            on login and when you visit your donations settings. You can disconnect your Metafy
+            account at any time from the Donations settings page, which deletes all stored Metafy
+            data. Metafy&apos;s own{" "}
+            <InlineLink href="https://metafy.gg/privacy">privacy policy</InlineLink> applies to
+            information held by Metafy.
+          </Text>
         </div>
 
         <div className="mb-6">
@@ -191,6 +208,11 @@ export function PrivacyView() {
               from third-party sources (for example RiftCodex). When you search or resolve cards,
               we do not send your identity to those sources; we only request card data for the
               lookups you trigger.
+            </ListItem>
+            <ListItem>
+              <strong className="font-semibold">Metafy.</strong> If you link your Metafy account,
+              we call the Metafy API using your OAuth access token to verify supporter status.
+              Metafy&apos;s privacy policy applies to data Metafy collects or processes.
             </ListItem>
             <ListItem>
               <strong className="font-semibold">Reddit / Devvit.</strong> As described above, the bot

--- a/packages/web/src/views/profile/profile-view.tsx
+++ b/packages/web/src/views/profile/profile-view.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState } from "react";
+import { Separator } from "@/components/ui/separator";
+import { FollowButton } from "@/components/profile/follow-button";
+import type { ProfileData } from "@/features/profile/api";
+
+interface ProfileViewProps {
+  profile: ProfileData;
+  isOwnProfile: boolean;
+}
+
+export function ProfileView({ profile, isOwnProfile }: ProfileViewProps) {
+  const [followerCount, setFollowerCount] = useState(profile.follower_count);
+
+  const initials = profile.username.slice(0, 2).toUpperCase();
+
+  return (
+    <div className="container max-w-2xl py-10">
+      <div className="flex items-start gap-6">
+        <div className="flex size-16 shrink-0 items-center justify-center rounded-full bg-muted text-lg font-semibold select-none">
+          {initials}
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-3">
+            <div className="min-w-0">
+              <h1 className="truncate text-xl font-semibold leading-tight">{profile.username}</h1>
+              <p className="text-sm text-muted-foreground">@{profile.handle}</p>
+            </div>
+            {!isOwnProfile && (
+              <div className="ml-auto shrink-0">
+                <FollowButton
+                  handle={profile.handle}
+                  initialIsFollowing={profile.is_following ?? false}
+                  onCountChange={(delta) => setFollowerCount((c) => c + delta)}
+                />
+              </div>
+            )}
+          </div>
+
+          <div className="mt-3 flex gap-4 text-sm">
+            <span>
+              <span className="font-semibold">{followerCount}</span>{" "}
+              <span className="text-muted-foreground">followers</span>
+            </span>
+            <span>
+              <span className="font-semibold">{profile.following_count}</span>{" "}
+              <span className="text-muted-foreground">following</span>
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <Separator className="my-8" />
+
+      <p className="text-sm text-muted-foreground text-center py-8">
+        No content yet.
+      </p>
+    </div>
+  );
+}

--- a/packages/web/src/views/profile/profile-view.tsx
+++ b/packages/web/src/views/profile/profile-view.tsx
@@ -16,7 +16,7 @@ export function ProfileView({ profile, isOwnProfile }: ProfileViewProps) {
   const initials = profile.username.slice(0, 2).toUpperCase();
 
   return (
-    <div className="container max-w-2xl py-10">
+    <div className="container py-8">
       <div className="flex items-start gap-6">
         <div className="flex size-16 shrink-0 items-center justify-center rounded-full bg-muted text-lg font-semibold select-none">
           {initials}

--- a/packages/web/src/views/profile/profile-view.tsx
+++ b/packages/web/src/views/profile/profile-view.tsx
@@ -1,20 +1,27 @@
 "use client";
 
 import { useState } from "react";
-import { Star, Users } from "lucide-react";
+import { Star, Users, ExternalLink } from "lucide-react";
 import { Separator } from "@/components/ui/separator";
+import { SocialIcon } from "@/components/ui/social-icon";
 import { FollowButton } from "@/components/profile/follow-button";
+import { SOCIAL_PLATFORMS } from "@/lib/social-platforms";
 import type { ProfileData } from "@/features/profile/api";
 
 interface ProfileViewProps {
   profile: ProfileData;
   isOwnProfile: boolean;
+  isLoggedIn: boolean;
 }
 
-export function ProfileView({ profile, isOwnProfile }: ProfileViewProps) {
+export function ProfileView({ profile, isOwnProfile, isLoggedIn }: ProfileViewProps) {
   const [followerCount, setFollowerCount] = useState(profile.follower_count);
 
   const initials = profile.username.slice(0, 2).toUpperCase();
+
+  const activeSocials = SOCIAL_PLATFORMS.filter(
+    (p) => profile.social_links[p.id]?.trim(),
+  );
 
   return (
     <div className="container py-8">
@@ -24,8 +31,8 @@ export function ProfileView({ profile, isOwnProfile }: ProfileViewProps) {
         </div>
 
         <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-3">
-            <div className="min-w-0">
+          <div className="flex items-start gap-3">
+            <div className="min-w-0 flex-1">
               <div className="flex items-center gap-2 flex-wrap">
                 <h1 className="truncate text-xl font-semibold leading-tight">{profile.username}</h1>
                 {profile.is_supporter && (
@@ -41,18 +48,37 @@ export function ProfileView({ profile, isOwnProfile }: ProfileViewProps) {
                   </span>
                 )}
               </div>
-              <p className="text-sm text-muted-foreground">@{profile.handle}</p>
+
+              <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 mt-0.5">
+                <p className="text-sm text-muted-foreground">@{profile.handle}</p>
+                {profile.pronouns.length > 0 && (
+                  <>
+                    <span className="text-muted-foreground/40">·</span>
+                    <p className="text-sm text-muted-foreground">
+                      {profile.pronouns.join(", ")}
+                    </p>
+                  </>
+                )}
+              </div>
             </div>
+
             {!isOwnProfile && (
-              <div className="ml-auto shrink-0">
+              <div className="shrink-0">
                 <FollowButton
                   handle={profile.handle}
                   initialIsFollowing={profile.is_following ?? false}
+                  isLoggedIn={isLoggedIn}
                   onCountChange={(delta) => setFollowerCount((c) => c + delta)}
                 />
               </div>
             )}
           </div>
+
+          {profile.bio && (
+            <p className="mt-2 text-sm text-muted-foreground whitespace-pre-line">
+              {profile.bio}
+            </p>
+          )}
 
           <div className="mt-3 flex gap-4 text-sm">
             <span>
@@ -64,6 +90,29 @@ export function ProfileView({ profile, isOwnProfile }: ProfileViewProps) {
               <span className="text-muted-foreground">following</span>
             </span>
           </div>
+
+          {activeSocials.length > 0 && (
+            <div className="mt-3 flex flex-wrap gap-2">
+              {activeSocials.map((platform) => {
+                const url = profile.social_links[platform.id]!;
+                const isUrl = url.startsWith("http");
+                return (
+                  <a
+                    key={platform.id}
+                    href={isUrl ? url : undefined}
+                    target={isUrl ? "_blank" : undefined}
+                    rel={isUrl ? "noopener noreferrer" : undefined}
+                    title={platform.label}
+                    className="flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs text-muted-foreground hover:text-foreground hover:border-foreground/30 transition-colors"
+                  >
+                    <SocialIcon svgPath={platform.svgPath} className="size-3.5" />
+                    <span>{platform.label}</span>
+                    {isUrl && <ExternalLink className="size-2.5 opacity-50" />}
+                  </a>
+                );
+              })}
+            </div>
+          )}
         </div>
       </div>
 

--- a/packages/web/src/views/profile/profile-view.tsx
+++ b/packages/web/src/views/profile/profile-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { Star, Users } from "lucide-react";
 import { Separator } from "@/components/ui/separator";
 import { FollowButton } from "@/components/profile/follow-button";
 import type { ProfileData } from "@/features/profile/api";
@@ -25,7 +26,21 @@ export function ProfileView({ profile, isOwnProfile }: ProfileViewProps) {
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-3">
             <div className="min-w-0">
-              <h1 className="truncate text-xl font-semibold leading-tight">{profile.username}</h1>
+              <div className="flex items-center gap-2 flex-wrap">
+                <h1 className="truncate text-xl font-semibold leading-tight">{profile.username}</h1>
+                {profile.is_supporter && (
+                  <span className="flex items-center gap-1 text-xs font-medium text-violet-500 shrink-0">
+                    <Star className="size-3 fill-current" />
+                    Supporter
+                  </span>
+                )}
+                {!profile.is_supporter && profile.is_member && (
+                  <span className="flex items-center gap-1 text-xs font-medium text-blue-500 shrink-0">
+                    <Users className="size-3" />
+                    Member
+                  </span>
+                )}
+              </div>
               <p className="text-sm text-muted-foreground">@{profile.handle}</p>
             </div>
             {!isOwnProfile && (

--- a/packages/web/src/views/settings/donations-view.tsx
+++ b/packages/web/src/views/settings/donations-view.tsx
@@ -1,0 +1,14 @@
+import { SettingsSubpageLayout } from "./settings-subpage-layout";
+import type { SettingsSection } from "./settings-subpage-layout";
+
+const sections: SettingsSection[] = [];
+
+export function DonationsView() {
+  return (
+    <SettingsSubpageLayout
+      title="Donations"
+      description="Support Riftseer and manage your donation history."
+      sections={sections}
+    />
+  );
+}

--- a/packages/web/src/views/settings/donations-view.tsx
+++ b/packages/web/src/views/settings/donations-view.tsx
@@ -1,14 +1,35 @@
+import { Suspense } from "react";
 import { SettingsSubpageLayout } from "./settings-subpage-layout";
-import type { SettingsSection } from "./settings-subpage-layout";
+import { MetafyAccountPanel } from "@/components/metafy/metafy-account-panel";
+import type { MetafyStatusResult } from "@/features/metafy/types";
 
-const sections: SettingsSection[] = [];
+interface DonationsViewProps {
+  metafyStatus: MetafyStatusResult | null;
+}
 
-export function DonationsView() {
+export function DonationsView({ metafyStatus }: DonationsViewProps) {
   return (
     <SettingsSubpageLayout
       title="Donations"
-      description="Support Riftseer and manage your donation history."
-      sections={sections}
+      description="Support Riftseer and manage your supporter status."
+      sections={[
+        {
+          heading: "Metafy",
+          rows: [
+            {
+              title: "Metafy Account",
+              description: metafyStatus?.linked
+                ? "Your Metafy account is linked. Supporters get an ad-free experience and a badge on their profile."
+                : "Link your Metafy account to unlock supporter perks if you have an active membership.",
+              control: (
+                <Suspense>
+                  <MetafyAccountPanel initialStatus={metafyStatus} />
+                </Suspense>
+              ),
+            },
+          ],
+        },
+      ]}
     />
   );
 }

--- a/packages/web/src/views/settings/notifications-view.tsx
+++ b/packages/web/src/views/settings/notifications-view.tsx
@@ -1,0 +1,14 @@
+import { SettingsSubpageLayout } from "./settings-subpage-layout";
+import type { SettingsSection } from "./settings-subpage-layout";
+
+const sections: SettingsSection[] = [];
+
+export function NotificationsView() {
+  return (
+    <SettingsSubpageLayout
+      title="Notifications"
+      description="Manage how and when you receive notifications."
+      sections={sections}
+    />
+  );
+}

--- a/packages/web/src/views/settings/preferences-view.tsx
+++ b/packages/web/src/views/settings/preferences-view.tsx
@@ -1,0 +1,14 @@
+import { SettingsSubpageLayout } from "./settings-subpage-layout";
+import type { SettingsSection } from "./settings-subpage-layout";
+
+const sections: SettingsSection[] = [];
+
+export function PreferencesView() {
+  return (
+    <SettingsSubpageLayout
+      title="User Preferences"
+      description="General user preferences to make the site exactly how you want it."
+      sections={sections}
+    />
+  );
+}

--- a/packages/web/src/views/settings/profile-settings-view.tsx
+++ b/packages/web/src/views/settings/profile-settings-view.tsx
@@ -1,0 +1,14 @@
+import { SettingsSubpageLayout } from "./settings-subpage-layout";
+import type { SettingsSection } from "./settings-subpage-layout";
+
+const sections: SettingsSection[] = [];
+
+export function ProfileSettingsView() {
+  return (
+    <SettingsSubpageLayout
+      title="User Profile"
+      description="Update your user profile (display name, pronouns, bio, etc)."
+      sections={sections}
+    />
+  );
+}

--- a/packages/web/src/views/settings/profile-settings-view.tsx
+++ b/packages/web/src/views/settings/profile-settings-view.tsx
@@ -1,14 +1,370 @@
-import { SettingsSubpageLayout } from "./settings-subpage-layout";
-import type { SettingsSection } from "./settings-subpage-layout";
+"use client";
 
-const sections: SettingsSection[] = [];
+import { useState, useTransition } from "react";
+import Link from "next/link";
+import { ChevronRight, Camera, X, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Separator } from "@/components/ui/separator";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { SocialIcon } from "@/components/ui/social-icon";
+import { validateSocialLink } from "@riftseer/types/social-links";
+import { SOCIAL_PLATFORMS } from "@/lib/social-platforms";
+import { updateProfileAction } from "@/features/profile/actions";
+import type { ProfileData } from "@/features/profile/api";
+import type { Session } from "@/features/auth/types";
 
-export function ProfileSettingsView() {
+const PRONOUN_PRESETS = [
+  "he/him",
+  "she/her",
+  "they/them",
+  "he/they",
+  "she/they",
+  "xe/xem",
+  "any/all",
+];
+
+const MAX_PRONOUNS = 3;
+const MAX_BIO = 300;
+
+interface Props {
+  session: Session;
+  profile: ProfileData | null;
+}
+
+export function ProfileSettingsView({ session, profile }: Props) {
+  const [displayName, setDisplayName] = useState(profile?.username ?? session.user.username ?? "");
+  const [bio, setBio] = useState(profile?.bio ?? "");
+  const [pronouns, setPronouns] = useState<string[]>(profile?.pronouns ?? []);
+  const [customPronoun, setCustomPronoun] = useState("");
+  const [socialLinks, setSocialLinks] = useState<Record<string, string>>(
+    profile?.social_links ?? {},
+  );
+  const [socialErrors, setSocialErrors] = useState<Record<string, string>>({});
+  const [feedback, setFeedback] = useState<{ type: "success" | "error"; message: string } | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const handle = profile?.handle ?? session.user.handle ?? "";
+  const initials = displayName.slice(0, 2).toUpperCase() || "??";
+
+  function togglePreset(preset: string) {
+    setPronouns((prev) => {
+      if (prev.includes(preset)) return prev.filter((p) => p !== preset);
+      if (prev.length >= MAX_PRONOUNS) return prev;
+      return [...prev, preset];
+    });
+  }
+
+  function removePronouns(p: string) {
+    setPronouns((prev) => prev.filter((x) => x !== p));
+  }
+
+  function addCustomPronoun() {
+    const trimmed = customPronoun.trim();
+    if (!trimmed || pronouns.includes(trimmed) || pronouns.length >= MAX_PRONOUNS) return;
+    setPronouns((prev) => [...prev, trimmed]);
+    setCustomPronoun("");
+  }
+
+  function handleSocialChange(id: string, value: string) {
+    setSocialLinks((prev) => {
+      const next = { ...prev };
+      if (value.trim()) {
+        next[id] = value;
+      } else {
+        delete next[id];
+      }
+      return next;
+    });
+
+    const err = value.trim() ? validateSocialLink(id, value) : null;
+    setSocialErrors((prev) => {
+      const next = { ...prev };
+      if (err) next[id] = err;
+      else delete next[id];
+      return next;
+    });
+  }
+
+  function handleSubmit() {
+    const errors: Record<string, string> = {};
+    for (const platform of SOCIAL_PLATFORMS) {
+      const val = socialLinks[platform.id]?.trim();
+      if (val) {
+        const err = validateSocialLink(platform.id, val);
+        if (err) errors[platform.id] = err;
+      }
+    }
+    if (Object.keys(errors).length > 0) {
+      setSocialErrors(errors);
+      setFeedback({ type: "error", message: "Fix the social link errors before saving." });
+      return;
+    }
+
+    setFeedback(null);
+    startTransition(async () => {
+      const result = await updateProfileAction({
+        username: displayName,
+        bio,
+        pronouns,
+        social_links: socialLinks,
+      });
+      if ("error" in result) {
+        setFeedback({ type: "error", message: result.error ?? "Failed to save profile." });
+      } else {
+        setFeedback({ type: "success", message: "Profile saved." });
+      }
+    });
+  }
+
   return (
-    <SettingsSubpageLayout
-      title="User Profile"
-      description="Update your user profile (display name, pronouns, bio, etc)."
-      sections={sections}
-    />
+    <div className="container py-8">
+      <nav className="flex items-center gap-1.5 text-sm text-muted-foreground mb-6">
+        <Link href="/settings" className="hover:text-foreground transition-colors">
+          Settings
+        </Link>
+        <ChevronRight className="size-3.5" />
+        <span className="text-foreground">User Profile</span>
+      </nav>
+
+      <div className="mb-8">
+        <h1 className="text-2xl font-semibold">User Profile</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Update your public profile — display name, bio, pronouns, and social links.
+        </p>
+      </div>
+
+      <div className="space-y-8">
+        {/* Avatar */}
+        <section>
+          <h2 className="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            Avatar
+          </h2>
+          <div className="flex items-center gap-5">
+            <div className="relative size-20 shrink-0">
+              <div className="flex size-20 items-center justify-center rounded-full bg-muted text-lg font-semibold select-none">
+                {initials}
+              </div>
+              <div className="absolute inset-0 flex items-center justify-center rounded-full bg-black/40 opacity-0 hover:opacity-100 transition-opacity cursor-not-allowed">
+                <Camera className="size-5 text-white" />
+              </div>
+            </div>
+            <div>
+              <p className="text-sm font-medium">Profile picture</p>
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                Avatar customization is coming soon.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <Separator />
+
+        {/* Basic Info */}
+        <section>
+          <h2 className="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            Basic Info
+          </h2>
+          <div className="space-y-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="display-name">Display name</Label>
+              <Input
+                id="display-name"
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+                maxLength={50}
+                placeholder="Your display name"
+              />
+              <p className="text-xs text-muted-foreground">
+                This is how your name appears across the site.
+              </p>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label>Username</Label>
+              <div className="flex items-center gap-2">
+                <div className="flex h-9 flex-1 items-center rounded-md border bg-muted/50 px-3 text-sm text-muted-foreground select-none">
+                  @{handle}
+                </div>
+                <Button asChild variant="outline" size="sm">
+                  <Link href="/settings/security">Change username</Link>
+                </Button>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Username changes are managed in Login &amp; Security. Note: changing your @handle
+                will break existing links to your profile.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <Separator />
+
+        {/* About */}
+        <section>
+          <h2 className="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            About
+          </h2>
+          <div className="space-y-4">
+            <div className="space-y-1.5">
+              <div className="flex items-center justify-between">
+                <Label htmlFor="bio">Bio</Label>
+                <span className="text-xs text-muted-foreground">
+                  {bio.length}/{MAX_BIO}
+                </span>
+              </div>
+              <Textarea
+                id="bio"
+                value={bio}
+                onChange={(e) => setBio(e.target.value.slice(0, MAX_BIO))}
+                placeholder="Tell people a little about yourself…"
+                rows={3}
+                className="resize-none"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>
+                Pronouns{" "}
+                <span className="font-normal text-muted-foreground">
+                  (up to {MAX_PRONOUNS})
+                </span>
+              </Label>
+
+              {/* Preset chips */}
+              <div className="flex flex-wrap gap-1.5">
+                {PRONOUN_PRESETS.map((preset) => {
+                  const selected = pronouns.includes(preset);
+                  const disabled = !selected && pronouns.length >= MAX_PRONOUNS;
+                  return (
+                    <button
+                      key={preset}
+                      type="button"
+                      onClick={() => togglePreset(preset)}
+                      disabled={disabled}
+                      className={[
+                        "rounded-full border px-3 py-1 text-xs font-medium transition-colors",
+                        selected
+                          ? "border-primary bg-primary text-primary-foreground"
+                          : "border-input bg-background text-foreground hover:bg-muted",
+                        disabled ? "cursor-not-allowed opacity-40" : "cursor-pointer",
+                      ].join(" ")}
+                    >
+                      {preset}
+                    </button>
+                  );
+                })}
+              </div>
+
+              {/* Selected pronouns */}
+              {pronouns.length > 0 && (
+                <div className="flex flex-wrap gap-1.5">
+                  {pronouns.map((p) => (
+                    <span
+                      key={p}
+                      className="flex items-center gap-1 rounded-full bg-secondary px-2.5 py-0.5 text-xs font-medium"
+                    >
+                      {p}
+                      <button
+                        type="button"
+                        onClick={() => removePronouns(p)}
+                        className="ml-0.5 rounded-full hover:text-destructive transition-colors"
+                        aria-label={`Remove ${p}`}
+                      >
+                        <X className="size-3" />
+                      </button>
+                    </span>
+                  ))}
+                </div>
+              )}
+
+              {/* Custom pronoun input */}
+              {pronouns.length < MAX_PRONOUNS && (
+                <div className="flex gap-2">
+                  <Input
+                    value={customPronoun}
+                    onChange={(e) => setCustomPronoun(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") {
+                        e.preventDefault();
+                        addCustomPronoun();
+                      }
+                    }}
+                    placeholder="Add custom (e.g. ey/em)"
+                    className="h-8 text-sm"
+                    maxLength={30}
+                  />
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={addCustomPronoun}
+                    disabled={!customPronoun.trim() || pronouns.includes(customPronoun.trim())}
+                    className="h-8 px-2"
+                  >
+                    <Plus className="size-3.5" />
+                  </Button>
+                </div>
+              )}
+            </div>
+          </div>
+        </section>
+
+        <Separator />
+
+        {/* Social Links */}
+        <section>
+          <h2 className="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            Social Links
+          </h2>
+          <div className="space-y-3">
+            {SOCIAL_PLATFORMS.map((platform) => (
+              <div key={platform.id} className="space-y-1">
+                <div className="flex items-center gap-3">
+                  <div className="flex w-28 shrink-0 items-center gap-2 text-sm text-muted-foreground">
+                    <SocialIcon
+                      svgPath={platform.svgPath}
+                      className="size-4"
+                      aria-label={platform.label}
+                    />
+                    <span className="truncate">{platform.label}</span>
+                  </div>
+                  <Input
+                    value={socialLinks[platform.id] ?? ""}
+                    onChange={(e) => handleSocialChange(platform.id, e.target.value)}
+                    placeholder={platform.placeholder}
+                    type="url"
+                    aria-invalid={!!socialErrors[platform.id]}
+                    className="text-sm"
+                  />
+                </div>
+                {socialErrors[platform.id] && (
+                  <p className="pl-31 text-xs text-destructive">
+                    {socialErrors[platform.id]}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <Separator />
+
+        {/* Feedback + Save */}
+        {feedback && (
+          <Alert variant={feedback.type === "error" ? "destructive" : "default"}>
+            <AlertDescription>{feedback.message}</AlertDescription>
+          </Alert>
+        )}
+
+        <div className="flex justify-end">
+          <Button onClick={handleSubmit} disabled={isPending}>
+            {isPending ? "Saving…" : "Save changes"}
+          </Button>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/packages/web/src/views/settings/security-view.tsx
+++ b/packages/web/src/views/settings/security-view.tsx
@@ -1,14 +1,447 @@
-import { SettingsSubpageLayout } from "./settings-subpage-layout";
-import type { SettingsSection } from "./settings-subpage-layout";
+"use client";
 
-const sections: SettingsSection[] = [];
+import { useState, useTransition, useActionState } from "react";
+import Link from "next/link";
+import { ChevronRight, Pencil, AlertTriangle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { updateHandleAction } from "@/features/profile/actions";
+import { changeEmailAction, changePasswordAction, deleteAccountAction } from "@/features/auth/actions";
+import type { Session } from "@/features/auth/types";
 
-export function SecurityView() {
+interface Props {
+  session: Session;
+}
+
+// ── Change Username Dialog ────────────────────────────────────────────────────
+
+function ChangeUsernameDialog({ currentHandle }: { currentHandle: string }) {
+  const [open, setOpen] = useState(false);
+  const [handle, setHandle] = useState(currentHandle);
+  const [feedback, setFeedback] = useState<{ type: "success" | "error"; message: string } | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setFeedback(null);
+    startTransition(async () => {
+      const result = await updateHandleAction(handle.trim().toLowerCase());
+      if ("error" in result) {
+        setFeedback({ type: "error", message: result.error ?? "Failed to update username." });
+      } else {
+        setFeedback({ type: "success", message: `Username changed to @${result.handle ?? handle}.` });
+        setTimeout(() => setOpen(false), 1200);
+      }
+    });
+  }
+
   return (
-    <SettingsSubpageLayout
-      title="Login & Security"
-      description="Update your password and other security features on your account."
-      sections={sections}
-    />
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          <Pencil className="size-3.5 mr-1.5" />
+          Edit username
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Change username</DialogTitle>
+          <DialogDescription>
+            Choose a new @handle. This will break any existing links to your profile.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="new-handle">New username</Label>
+            <div className="flex items-center">
+              <span className="flex h-9 items-center rounded-l-md border border-r-0 bg-muted px-3 text-sm text-muted-foreground select-none">
+                @
+              </span>
+              <Input
+                id="new-handle"
+                value={handle}
+                onChange={(e) => setHandle(e.target.value.toLowerCase().replace(/[^a-z0-9_]/g, ""))}
+                className="rounded-l-none"
+                minLength={3}
+                maxLength={30}
+                pattern="[a-z0-9_]{3,30}"
+                required
+                autoFocus
+              />
+            </div>
+            <p className="text-xs text-muted-foreground">
+              3–30 characters: lowercase letters, numbers, underscores.
+            </p>
+          </div>
+
+          <Alert>
+            <AlertTriangle className="size-4" />
+            <AlertDescription>
+              Changing your username will break existing profile links. There is no redirect.
+            </AlertDescription>
+          </Alert>
+
+          {feedback && (
+            <Alert variant={feedback.type === "error" ? "destructive" : "default"}>
+              <AlertDescription>{feedback.message}</AlertDescription>
+            </Alert>
+          )}
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isPending || handle.trim() === currentHandle}>
+              {isPending ? "Saving…" : "Save username"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── Change Email Dialog ───────────────────────────────────────────────────────
+
+function ChangeEmailDialog({ currentEmail }: { currentEmail: string }) {
+  const [open, setOpen] = useState(false);
+  const [state, action, isPending] = useActionState(changeEmailAction, null);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          <Pencil className="size-3.5 mr-1.5" />
+          Change email
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Change email address</DialogTitle>
+          <DialogDescription>
+            A confirmation link will be sent to your new address. Your current email stays active
+            until you confirm.
+          </DialogDescription>
+        </DialogHeader>
+        <form action={action} className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="current-email">Current email</Label>
+            <Input id="current-email" value={currentEmail} disabled className="bg-muted/50" />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="new-email">New email</Label>
+            <Input
+              id="new-email"
+              name="email"
+              type="email"
+              required
+              placeholder="you@example.com"
+              autoFocus
+            />
+          </div>
+
+          {state && "error" in state && state.error && (
+            <Alert variant="destructive">
+              <AlertDescription>{state.error}</AlertDescription>
+            </Alert>
+          )}
+          {state && "ok" in state && state.ok && (
+            <Alert>
+              <AlertDescription>
+                Confirmation email sent. Check your inbox to complete the change.
+              </AlertDescription>
+            </Alert>
+          )}
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isPending}>
+              {isPending ? "Sending…" : "Send confirmation"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── Change Password Dialog ────────────────────────────────────────────────────
+
+function ChangePasswordDialog() {
+  const [open, setOpen] = useState(false);
+  const [state, action, isPending] = useActionState(changePasswordAction, null);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          <Pencil className="size-3.5 mr-1.5" />
+          Change password
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Change password</DialogTitle>
+          <DialogDescription>
+            Enter your current password and choose a new one.
+          </DialogDescription>
+        </DialogHeader>
+        <form action={action} className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="current-password">Current password</Label>
+            <Input
+              id="current-password"
+              name="current_password"
+              type="password"
+              required
+              autoFocus
+              autoComplete="current-password"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="new-password">New password</Label>
+            <Input
+              id="new-password"
+              name="new_password"
+              type="password"
+              required
+              minLength={8}
+              autoComplete="new-password"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="confirm-password">Confirm new password</Label>
+            <Input
+              id="confirm-password"
+              name="confirm_password"
+              type="password"
+              required
+              autoComplete="new-password"
+            />
+          </div>
+
+          {state && "error" in state && state.error && (
+            <Alert variant="destructive">
+              <AlertDescription>{state.error}</AlertDescription>
+            </Alert>
+          )}
+          {state && "ok" in state && state.ok && (
+            <Alert>
+              <AlertDescription>Password changed successfully.</AlertDescription>
+            </Alert>
+          )}
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isPending}>
+              {isPending ? "Updating…" : "Update password"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── Delete Account Dialog ─────────────────────────────────────────────────────
+
+function DeleteAccountDialog({ handle }: { handle: string }) {
+  const [open, setOpen] = useState(false);
+  const [confirmation, setConfirmation] = useState("");
+  const [state, action, isPending] = useActionState(deleteAccountAction, null);
+
+  const confirmed = confirmation.toLowerCase() === handle.toLowerCase();
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="destructive" size="sm">
+          Delete account
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Delete account</DialogTitle>
+          <DialogDescription>
+            This is permanent. All your data will be deleted and cannot be recovered.
+          </DialogDescription>
+        </DialogHeader>
+        <form action={action} className="space-y-4">
+          <Alert variant="destructive">
+            <AlertTriangle className="size-4" />
+            <AlertDescription>
+              Deleting your account will permanently remove your profile, social links, follower
+              connections, and any other data associated with @{handle}.
+            </AlertDescription>
+          </Alert>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="delete-confirm">
+              Type <strong>@{handle}</strong> to confirm
+            </Label>
+            <Input
+              id="delete-confirm"
+              name="confirmation"
+              value={confirmation}
+              onChange={(e) => setConfirmation(e.target.value)}
+              placeholder={handle}
+              autoComplete="off"
+              autoFocus
+            />
+          </div>
+
+          {state && "error" in state && state.error && (
+            <Alert variant="destructive">
+              <AlertDescription>{state.error}</AlertDescription>
+            </Alert>
+          )}
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="destructive"
+              disabled={!confirmed || isPending}
+            >
+              {isPending ? "Deleting…" : "Permanently delete account"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── Main View ─────────────────────────────────────────────────────────────────
+
+export function SecurityView({ session }: Props) {
+  const handle = session.user.handle ?? "";
+  const email = session.user.email ?? "";
+
+  const maskedEmail = email.includes("@")
+    ? `${email.slice(0, 2)}${"•".repeat(Math.max(0, email.indexOf("@") - 2))}${email.slice(email.indexOf("@"))}`
+    : email;
+
+  return (
+    <div className="container py-8">
+      <nav className="flex items-center gap-1.5 text-sm text-muted-foreground mb-6">
+        <Link href="/settings" className="hover:text-foreground transition-colors">
+          Settings
+        </Link>
+        <ChevronRight className="size-3.5" />
+        <span className="text-foreground">Login &amp; Security</span>
+      </nav>
+
+      <div className="mb-8">
+        <h1 className="text-2xl font-semibold">Login &amp; Security</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Manage your username, email address, and password.
+        </p>
+      </div>
+
+      <div className="space-y-8">
+        {/* Account */}
+        <section>
+          <h2 className="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            Account
+          </h2>
+          <div className="rounded-lg border divide-y">
+            <div className="flex items-center justify-between gap-4 px-4 py-4">
+              <div className="min-w-0">
+                <p className="text-sm font-medium">Username</p>
+                <p className="mt-0.5 text-sm text-muted-foreground">@{handle}</p>
+                <p className="mt-0.5 text-xs text-muted-foreground">
+                  Changing your username will break existing links to your profile.
+                </p>
+              </div>
+              <div className="shrink-0">
+                <ChangeUsernameDialog currentHandle={handle} />
+              </div>
+            </div>
+
+            <div className="flex items-center justify-between gap-4 px-4 py-4">
+              <div className="min-w-0">
+                <p className="text-sm font-medium">Email address</p>
+                <p className="mt-0.5 text-sm text-muted-foreground">{maskedEmail}</p>
+                <p className="mt-0.5 text-xs text-muted-foreground">
+                  A confirmation link will be sent to your new address.
+                </p>
+              </div>
+              <div className="shrink-0">
+                <ChangeEmailDialog currentEmail={email} />
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <Separator />
+
+        {/* Password */}
+        <section>
+          <h2 className="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            Password
+          </h2>
+          <div className="rounded-lg border">
+            <div className="flex items-center justify-between gap-4 px-4 py-4">
+              <div className="min-w-0">
+                <p className="text-sm font-medium">Password</p>
+                <p className="mt-0.5 text-sm text-muted-foreground tracking-widest">
+                  ••••••••••••
+                </p>
+                <p className="mt-0.5 text-xs text-muted-foreground">
+                  You&apos;ll need your current password to set a new one.
+                </p>
+              </div>
+              <div className="shrink-0 flex flex-col gap-2 items-end">
+                <ChangePasswordDialog />
+                <Button asChild variant="ghost" size="sm" className="text-xs h-7 text-muted-foreground">
+                  <Link href="/auth/forgot-password">Forgot password?</Link>
+                </Button>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <Separator />
+
+        {/* Danger zone */}
+        <section>
+          <h2 className="mb-3 text-xs font-medium uppercase tracking-wider text-destructive">
+            Danger Zone
+          </h2>
+          <div className="rounded-lg border border-destructive/30">
+            <div className="flex items-center justify-between gap-4 px-4 py-4">
+              <div className="min-w-0">
+                <p className="text-sm font-medium">Delete account</p>
+                <p className="mt-0.5 text-xs text-muted-foreground">
+                  Permanently delete your account and all associated data. This cannot be undone.
+                </p>
+              </div>
+              <div className="shrink-0">
+                <DeleteAccountDialog handle={handle} />
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
   );
 }

--- a/packages/web/src/views/settings/security-view.tsx
+++ b/packages/web/src/views/settings/security-view.tsx
@@ -1,0 +1,14 @@
+import { SettingsSubpageLayout } from "./settings-subpage-layout";
+import type { SettingsSection } from "./settings-subpage-layout";
+
+const sections: SettingsSection[] = [];
+
+export function SecurityView() {
+  return (
+    <SettingsSubpageLayout
+      title="Login & Security"
+      description="Update your password and other security features on your account."
+      sections={sections}
+    />
+  );
+}

--- a/packages/web/src/views/settings/settings-index-view.tsx
+++ b/packages/web/src/views/settings/settings-index-view.tsx
@@ -1,0 +1,70 @@
+import Link from "next/link";
+import { Bell, ChevronRight, Heart, Lock, Settings, User } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import type { LucideIcon } from "lucide-react";
+
+interface SettingsCard {
+  href: string;
+  icon: LucideIcon;
+  title: string;
+  description: string;
+}
+
+const SETTINGS_CARDS: SettingsCard[] = [
+  {
+    href: "/settings/preferences",
+    icon: Settings,
+    title: "User Preferences",
+    description: "General user preferences to make the site exactly how you want it.",
+  },
+  {
+    href: "/settings/profile",
+    icon: User,
+    title: "User Profile",
+    description: "Update your user profile (display name, pronouns, bio, etc).",
+  },
+  {
+    href: "/settings/security",
+    icon: Lock,
+    title: "Login & Security",
+    description: "Update your password and other security features on your account.",
+  },
+  {
+    href: "/settings/notifications",
+    icon: Bell,
+    title: "Notifications",
+    description: "Manage how and when you receive notifications.",
+  },
+  {
+    href: "/settings/donations",
+    icon: Heart,
+    title: "Donations",
+    description: "Support Riftseer and manage your donation history.",
+  },
+];
+
+export function SettingsIndexView() {
+  return (
+    <div className="container py-8">
+      <h1 className="mb-8 text-2xl font-semibold">Settings</h1>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {SETTINGS_CARDS.map(({ href, icon: Icon, title, description }) => (
+          <Link key={href} href={href} className="block group">
+            <Card className="h-full transition-colors hover:border-foreground/30">
+              <CardContent className="pt-6 pb-5 px-5 flex flex-col gap-4">
+                <Icon className="size-6 text-violet-400" strokeWidth={1.75} />
+                <div>
+                  <div className="flex items-center gap-1.5">
+                    <span className="font-semibold text-sm">{title}</span>
+                    <ChevronRight className="size-3.5 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+                  </div>
+                  <p className="mt-1.5 text-xs text-muted-foreground leading-relaxed">{description}</p>
+                </div>
+              </CardContent>
+            </Card>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/views/settings/settings-subpage-layout.tsx
+++ b/packages/web/src/views/settings/settings-subpage-layout.tsx
@@ -1,0 +1,69 @@
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
+import { Separator } from "@/components/ui/separator";
+
+interface SettingRow {
+  title: string;
+  description?: string;
+  control?: React.ReactNode;
+}
+
+export interface SettingsSection {
+  heading?: string;
+  rows: SettingRow[];
+}
+
+interface Props {
+  title: string;
+  description: string;
+  sections?: SettingsSection[];
+}
+
+export function SettingsSubpageLayout({ title, description, sections = [] }: Props) {
+  return (
+    <div className="container py-8">
+      <nav className="flex items-center gap-1.5 text-sm text-muted-foreground mb-6">
+        <Link href="/settings" className="hover:text-foreground transition-colors">
+          Settings
+        </Link>
+        <ChevronRight className="size-3.5" />
+        <span className="text-foreground">{title}</span>
+      </nav>
+
+      <div className="mb-8">
+        <h1 className="text-2xl font-semibold">{title}</h1>
+        <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+      </div>
+
+      {sections.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No settings available yet.</p>
+      ) : (
+        <div className="space-y-8">
+          {sections.map((section, i) => (
+            <div key={i}>
+              {section.heading && (
+                <h2 className="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                  {section.heading}
+                </h2>
+              )}
+              <div className="rounded-lg border divide-y">
+                {section.rows.map((row, j) => (
+                  <div key={j} className="flex items-center justify-between gap-4 px-4 py-3">
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium">{row.title}</p>
+                      {row.description && (
+                        <p className="mt-0.5 text-xs text-muted-foreground">{row.description}</p>
+                      )}
+                    </div>
+                    {row.control && <div className="shrink-0">{row.control}</div>}
+                  </div>
+                ))}
+              </div>
+              {i < sections.length - 1 && <Separator className="mt-8" />}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/supabase/migrations/20260514000000_add_profiles_and_follows.sql
+++ b/supabase/migrations/20260514000000_add_profiles_and_follows.sql
@@ -1,0 +1,37 @@
+-- profiles: one row per auth user, created on register
+CREATE TABLE IF NOT EXISTS public.profiles (
+  id          uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  username    text NOT NULL,
+  handle      text NOT NULL,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  updated_at  timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT profiles_username_length CHECK (char_length(username) BETWEEN 1 AND 50),
+  CONSTRAINT profiles_handle_format  CHECK (handle ~ '^[a-z0-9_]{3,30}$'),
+  CONSTRAINT profiles_handle_unique  UNIQUE (handle)
+);
+
+-- follows: directed (follower → following) edges
+CREATE TABLE IF NOT EXISTS public.follows (
+  follower_id   uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  following_id  uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (follower_id, following_id),
+  CONSTRAINT no_self_follow CHECK (follower_id <> following_id)
+);
+
+CREATE INDEX IF NOT EXISTS follows_follower_idx  ON public.follows (follower_id);
+CREATE INDEX IF NOT EXISTS follows_following_idx ON public.follows (following_id);
+
+-- RLS
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.follows  ENABLE ROW LEVEL SECURITY;
+
+-- Profiles: anyone can read; owner can insert/update their own row
+CREATE POLICY profiles_public_read  ON public.profiles FOR SELECT USING (true);
+CREATE POLICY profiles_owner_insert ON public.profiles FOR INSERT WITH CHECK (auth.uid() = id);
+CREATE POLICY profiles_owner_update ON public.profiles FOR UPDATE USING (auth.uid() = id);
+
+-- Follows: anyone can read; authenticated users manage their own follows
+CREATE POLICY follows_public_read ON public.follows FOR SELECT USING (true);
+CREATE POLICY follows_auth_insert ON public.follows FOR INSERT WITH CHECK (auth.uid() = follower_id);
+CREATE POLICY follows_auth_delete ON public.follows FOR DELETE  USING (auth.uid() = follower_id);

--- a/supabase/migrations/20260515000000_add_linked_accounts.sql
+++ b/supabase/migrations/20260515000000_add_linked_accounts.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS public.linked_accounts (
+  id                uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id           uuid        NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  provider          text        NOT NULL,
+  provider_user_id  text        NOT NULL,
+  provider_username text,
+  access_token      text,
+  refresh_token     text,
+  is_supporter      boolean     NOT NULL DEFAULT false,
+  status_checked_at timestamptz,
+  linked_at         timestamptz NOT NULL DEFAULT now(),
+  updated_at        timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT linked_accounts_user_provider_unique UNIQUE (user_id, provider)
+);
+
+CREATE INDEX IF NOT EXISTS linked_accounts_user_id_idx ON public.linked_accounts (user_id);
+
+CREATE TRIGGER linked_accounts_updated_at
+  BEFORE UPDATE ON public.linked_accounts
+  FOR EACH ROW EXECUTE FUNCTION trigger_set_updated_at();
+
+ALTER TABLE public.linked_accounts ENABLE ROW LEVEL SECURITY;
+-- No RLS policies — all access goes through the API worker using the service role client.
+-- The absence of policies under enabled RLS blocks all non-service-role access.

--- a/supabase/migrations/20260515010000_add_linked_accounts_is_member.sql
+++ b/supabase/migrations/20260515010000_add_linked_accounts_is_member.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.linked_accounts ADD COLUMN IF NOT EXISTS is_member boolean NOT NULL DEFAULT false;

--- a/supabase/migrations/20260515020000_add_profile_fields.sql
+++ b/supabase/migrations/20260515020000_add_profile_fields.sql
@@ -1,0 +1,9 @@
+-- Add extended profile fields to profiles table
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS bio          text,
+  ADD COLUMN IF NOT EXISTS pronouns     text[]  NOT NULL DEFAULT '{}',
+  ADD COLUMN IF NOT EXISTS social_links jsonb   NOT NULL DEFAULT '{}';
+
+ALTER TABLE public.profiles
+  ADD CONSTRAINT profiles_bio_length      CHECK (bio IS NULL OR char_length(bio) <= 300),
+  ADD CONSTRAINT profiles_pronouns_count  CHECK (array_length(pronouns, 1) IS NULL OR array_length(pronouns, 1) <= 3);


### PR DESCRIPTION
## Summary

- Adds public user profiles at `/u/[handle]` with follower/following counts and a follow button for authenticated users.
- Introduces a settings section (`/settings/*`) covering profile editing (display name, bio, pronouns, social links), security (email/password changes), preferences, notifications, and donations.
- Integrates Metafy OAuth for account linking, supporter/member badges in the nav, and a donations settings panel with webhook-driven status updates.
- Extends the API with profile routes (`GET /users/:handle`, follow/unfollow) and Metafy connect/disconnect/status endpoints; registration now requires a unique handle.
- Adds Supabase migrations for `profiles`, `follows`, `linked_accounts`, and profile field extensions.

Targets `next-js-frontend` — this PR adds the profile/settings/Metafy work on top of the Next.js web migration.

## Database migrations

Apply before deploying:

- `20260514000000_add_profiles_and_follows.sql`
- `20260515000000_add_linked_accounts.sql`
- `20260515020000_add_profile_fields.sql`
- `20260515010000_add_linked_accounts_is_member.sql`

## New env / secrets

API Worker (`packages/api`):

- `METAFY_CLIENT_ID`, `METAFY_CLIENT_SECRET`, `METAFY_COMMUNITY_ID`, `METAFY_REDIRECT_URI` (required)
- `METAFY_WEBHOOK_SECRET` (optional, Partners only)

## Test plan

- [ ] Run `supabase db push` (or apply migrations manually) against a dev project
- [ ] Register a new account with a handle; confirm profile row is created
- [ ] Visit `/u/<handle>` — profile displays bio, pronouns, social links, follower counts
- [ ] Sign in as a second user; follow/unfollow from the profile page
- [ ] Edit profile at `/settings/profile` — save display name, bio, pronouns, social links
- [ ] Change email/password at `/settings/security`
- [ ] Link Metafy account from `/settings/donations`; confirm supporter/member badge in nav
- [ ] Disconnect Metafy account
- [ ] `bun typecheck` and `bun test` pass