### PR TITLE
Fix legacy frontend image CSP

### DIFF
--- a/packages/frontend/public/_headers
+++ b/packages/frontend/public/_headers
@@ -1,5 +1,5 @@
 /*
-  Content-Security-Policy: default-src 'self'; connect-src 'self' https://api.riftseer.com https://*.posthog.com; img-src 'self' data: https://cards.riftcodex.com https://*.riftcodex.com https://cmsassets.rgpub.io https://tcgplayer-cdn.tcgplayer.com; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-ancestors 'none'
+  Content-Security-Policy: default-src 'self'; connect-src 'self' https://api.riftseer.com https://*.posthog.com; img-src 'self' data: https://img.riftseer.com https://cards.riftcodex.com https://*.riftcodex.com https://cmsassets.rgpub.io https://tcgplayer-cdn.tcgplayer.com; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-ancestors 'none'
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin


### PR DESCRIPTION
## What changed

- Allow `https://img.riftseer.com` in the legacy frontend's `img-src` Content Security Policy.

## Why

Card images are now served from Riftseer's hosted image domain. The legacy frontend's CSP still allowed only the previous RiftCodex, Riot, and TCGPlayer image sources, so browsers blocked hosted card images.

## Impact

Legacy frontend card images served from `img.riftseer.com` can load normally while the existing image-source restrictions remain in place.

## Validation

- Ran the legacy frontend production build successfully with `bun run build`.
- Confirmed the generated `dist/_headers` contains `https://img.riftseer.com` in `img-src`.
- Ran `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated security settings to allow images hosted on the approved image domain to display correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->