### PR TITLE
fix(types): repair RiftCodex flavour text (4/7)

### DIFF
--- a/packages/core/src/providers/supabase.ts
+++ b/packages/core/src/providers/supabase.ts
@@ -27,6 +27,7 @@ import type {
   RelatedCard,
   CardPriceEntry,
 } from "../types.ts";
+import { repairFlavourText } from "@riftseer/types/card-text";
 import { logger } from "../logger.ts";
 import { getSupabaseClient } from "../supabase/client.ts";
 import { normalizeCardName } from "../normalize.ts";
@@ -126,7 +127,9 @@ function dbRowToCard(row: DBCardRow): Card {
     rulings: row.rulings_id ? { rulings_id: row.rulings_id } : undefined,
     attributes: row.attributes,
     classification: row.classification,
-    text: row.text,
+    text: row.text?.flavour
+      ? { ...row.text, flavour: repairFlavourText(row.text.flavour) }
+      : row.text,
     artist: row.artists?.name,
     artist_id: row.artist_id ?? undefined,
     metadata: row.metadata,

--- a/packages/ingest-worker/src/sources/riftcodex.ts
+++ b/packages/ingest-worker/src/sources/riftcodex.ts
@@ -7,6 +7,7 @@
 
 import { normalizeCardName, logger } from "../utils.ts";
 import type { Card } from "@riftseer/types";
+import { repairFlavourText } from "@riftseer/types/card-text";
 
 const PAGE_SIZE = 100;
 
@@ -217,7 +218,9 @@ export function rawToCard(raw: RawCard): Card {
     text: {
       rich: raw.text?.rich || undefined,
       plain: raw.text?.plain || undefined,
-      flavour: raw.text?.flavour || undefined,
+      flavour: raw.text?.flavour
+        ? repairFlavourText(raw.text.flavour)
+        : undefined,
     },
     artist: raw.media?.artist || undefined,
     metadata: {

--- a/packages/types/src/__tests__/card-text-clipboard.test.ts
+++ b/packages/types/src/__tests__/card-text-clipboard.test.ts
@@ -3,8 +3,56 @@ import {
   decodeCardTextEntities,
   formatCardTextForClipboard,
   maskIconTokens,
+  repairFlavourText,
   restoreIconTokens,
 } from "../card-text.ts";
+
+describe("repairFlavourText", () => {
+  it("restores a missing opening dialogue quote before attribution", () => {
+    expect(repairFlavourText('If you hit a wall, hit it hard!"\r\n \r\n- Vi')).toBe(
+      '"If you hit a wall, hit it hard!"\n \n- Vi',
+    );
+    expect(repairFlavourText('Art shall blossom from your fear."\n - Jhin')).toBe(
+      '"Art shall blossom from your fear."\n - Jhin',
+    );
+  });
+
+  it("is idempotent when the opening quote is already present", () => {
+    const ok = '"Peace within, peace without."\n\n- Master Yi';
+    expect(repairFlavourText(ok)).toBe(ok);
+  });
+
+  it("leaves unquoted flavour unchanged", () => {
+    expect(repairFlavourText("A quiet resolve.")).toBe("A quiet resolve.");
+  });
+
+  it("strips stray HTML debris from upstream flavour", () => {
+    expect(
+      repairFlavourText('Hey, where is everyone?" \r\n- Common last words</em'),
+    ).toBe('"Hey, where is everyone?" \n- Common last words');
+  });
+
+  it("leaves prose that quotes a word mid-sentence alone", () => {
+    // The attribution rule keys on a newline; a same-line dash after a quoted
+    // word is ordinary prose, not the upstream missing-opening-quote bug.
+    const prose = 'He said "run" - and she ran.';
+    expect(repairFlavourText(prose)).toBe(prose);
+    expect(repairFlavourText('They called it the "Rift" - a wound.')).toBe(
+      'They called it the "Rift" - a wound.',
+    );
+  });
+
+  it("keeps angle brackets that are not HTML tags", () => {
+    expect(repairFlavourText("<sigh> Another day.")).toBe("<sigh> Another day.");
+    expect(repairFlavourText("I <3 the Rift.")).toBe("I <3 the Rift.");
+  });
+
+  it("still repairs when the attribution uses an en or em dash", () => {
+    expect(repairFlavourText('Only the worthy."\n— Leona')).toBe(
+      '"Only the worthy."\n— Leona',
+    );
+  });
+});
 
 describe("decodeCardTextEntities", () => {
   it("decodes common HTML entities from upstream rules text", () => {

--- a/packages/types/src/__tests__/card-text-clipboard.test.ts
+++ b/packages/types/src/__tests__/card-text-clipboard.test.ts
@@ -32,22 +32,36 @@ describe("repairFlavourText", () => {
     ).toBe('"Hey, where is everyone?" \n- Common last words');
   });
 
-  it("leaves prose that quotes a word mid-sentence alone", () => {
-    // The attribution rule keys on a newline; a same-line dash after a quoted
-    // word is ordinary prose, not the upstream missing-opening-quote bug.
-    const prose = 'He said "run" - and she ran.';
-    expect(repairFlavourText(prose)).toBe(prose);
-    expect(repairFlavourText('They called it the "Rift" - a wound.')).toBe(
-      'They called it the "Rift" - a wound.',
+  // The attribution runs on after the closing quote far more often than it
+  // starts a new line (82 vs 27 of the 109 affected cards), so this shape
+  // matters more than the newline one above.
+  it("restores the quote when the attribution is on the same line", () => {
+    expect(
+      repairFlavourText('Those who follow me follow destiny!" - Azir'),
+    ).toBe('"Those who follow me follow destiny!" - Azir');
+    expect(repairFlavourText(`GET 'EM, CHOMPIES!" -Jinx`)).toBe(
+      `"GET 'EM, CHOMPIES!" -Jinx`,
     );
   });
 
-  it("keeps angle brackets that are not HTML tags", () => {
-    expect(repairFlavourText("<sigh> Another day.")).toBe("<sigh> Another day.");
+  it("strips a closing tag that upstream leaves after the quote", () => {
+    expect(
+      repairFlavourText('One of us finds peace. One of us walks away."</e>'),
+    ).toBe('One of us finds peace. One of us walks away."');
+  });
+
+  it("strips leading tag debris without eating the rest of the text", () => {
+    // A greedy `[^>]*` on this unterminated tag consumed the whole flavour.
+    expect(repairFlavourText('<em?"I will light our path.')).toBe(
+      '"I will light our path.',
+    );
+  });
+
+  it("keeps angle brackets that cannot be a tag", () => {
     expect(repairFlavourText("I <3 the Rift.")).toBe("I <3 the Rift.");
   });
 
-  it("still repairs when the attribution uses an en or em dash", () => {
+  it("still repairs when the attribution uses an em dash", () => {
     expect(repairFlavourText('Only the worthy."\n— Leona')).toBe(
       '"Only the worthy."\n— Leona',
     );

--- a/packages/types/src/__tests__/card-text-clipboard.test.ts
+++ b/packages/types/src/__tests__/card-text-clipboard.test.ts
@@ -26,6 +26,13 @@ describe("repairFlavourText", () => {
     expect(repairFlavourText("A quiet resolve.")).toBe("A quiet resolve.");
   });
 
+  it("does not treat a mid-sentence quoted word as an attribution", () => {
+    // The dash here is punctuation, not a trailing attribution, so nothing
+    // should gain an opening quote.
+    const aside = 'The word "power" - not a rule.';
+    expect(repairFlavourText(aside)).toBe(aside);
+  });
+
   it("strips stray HTML debris from upstream flavour", () => {
     expect(
       repairFlavourText('Hey, where is everyone?" \r\n- Common last words</em'),

--- a/packages/types/src/__tests__/card-text-clipboard.test.ts
+++ b/packages/types/src/__tests__/card-text-clipboard.test.ts
@@ -35,13 +35,23 @@ describe("repairFlavourText", () => {
   // The attribution runs on after the closing quote far more often than it
   // starts a new line (82 vs 27 of the 109 affected cards), so this shape
   // matters more than the newline one above.
-  it("restores the quote when the attribution is on the same line", () => {
+  it("restores the quote and breaks a run-on attribution onto its own line", () => {
     expect(
       repairFlavourText('Those who follow me follow destiny!" - Azir'),
-    ).toBe('"Those who follow me follow destiny!" - Azir');
-    expect(repairFlavourText(`GET 'EM, CHOMPIES!" -Jinx`)).toBe(
-      `"GET 'EM, CHOMPIES!" -Jinx`,
+    ).toBe('"Those who follow me follow destiny!"\n- Azir');
+    expect(repairFlavourText(`We're gonna be rich!" -Common Last Words`)).toBe(
+      `"We're gonna be rich!"\n-Common Last Words`,
     );
+  });
+
+  it("leaves an attribution that already has its own line where it is", () => {
+    const spaced = '"If you hit a wall, hit it hard!"\n \n- Vi';
+    expect(repairFlavourText(spaced)).toBe(spaced);
+  });
+
+  it("does not break on a dash inside the quoted line", () => {
+    const inline = '"A half-measure is no measure."';
+    expect(repairFlavourText(inline)).toBe(inline);
   });
 
   it("strips a closing tag that upstream leaves after the quote", () => {

--- a/packages/types/src/card-text.ts
+++ b/packages/types/src/card-text.ts
@@ -55,12 +55,15 @@ export function repairFlavourText(flavour: string): string {
   const lead = leadMatch?.[0] ?? "";
   const body = text.slice(lead.length);
   if (body.length === 0) return text;
-  if (body.startsWith('"') || body.startsWith("\u201c")) return lead + body;
 
-  if (ORPHANED_CLOSING_QUOTE.test(body)) {
-    return `${lead}"${body}`;
-  }
-  return lead + body;
+  const quoted =
+    body.startsWith('"') || body.startsWith("\u201c")
+      ? body
+      : ORPHANED_CLOSING_QUOTE.test(body)
+        ? `"${body}`
+        : body;
+
+  return lead + quoted.replace(RUN_ON_ATTRIBUTION, "$1\n$2");
 }
 
 /**
@@ -83,6 +86,17 @@ const HTML_DEBRIS_TAIL = /<\/?[a-zA-Z][a-zA-Z0-9]*$/;
  * and every one is a genuine missing opening quote.
  */
 const ORPHANED_CLOSING_QUOTE = /["”]\s*(?:\n\s*)*[-–—]\s*\S/;
+
+/**
+ * A dashed attribution running on after the closing quote (`..." -Azir`).
+ * Upstream is inconsistent about this: 27 cards put the attribution on its own
+ * line and 82 leave it inline. Normalising to the newline form makes the two
+ * groups render alike, and is what lets `whitespace-pre-line` show the break.
+ *
+ * Anchored to the end so only a trailing attribution is moved, never a dash
+ * inside the quoted line.
+ */
+const RUN_ON_ATTRIBUTION = /(["”])[^\S\n]*([-–—][^\n]*\S)\s*$/;
 
 /** Upstream rules text sometimes ships HTML entities (`&quot;`, `&gt;`, …). */
 export function decodeCardTextEntities(text: string): string {

--- a/packages/types/src/card-text.ts
+++ b/packages/types/src/card-text.ts
@@ -35,17 +35,21 @@ function isUnicodeScalarValue(value: number): boolean {
  *   "If you hit a wall, hit it hard!"\n- Vi
  *
  * Also strips stray HTML tag debris sometimes left in the same field.
- * Idempotent: already-correct flavours are unchanged.
  *
- * Both rules are deliberately narrow, because a false positive silently
- * corrupts card text this platform is the source of truth for: the quote is
- * only restored when the attribution sits on its own line, and only known
- * formatting tags are stripped. Prose that merely quotes a word mid-sentence
- * and non-HTML angle brackets ("I <3 ...", "<sigh>") are left alone.
+ * The attribution may sit on its own line ("...!"\n- Vi) or run on after the
+ * closing quote ("...!" -Azir); both shapes occur upstream, roughly 27 and 82
+ * times respectively across the 770 cards that carry flavour text. Requiring a
+ * newline would silently skip the larger group.
+ *
+ * Idempotent: text that already opens with a quote is returned untouched, so
+ * running this on both ingest and read never doubles the quote.
  */
 export function repairFlavourText(flavour: string): string {
   let text = flavour.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
-  text = text.replace(HTML_DEBRIS, "");
+  text = text
+    .replace(HTML_TAG, "")
+    .replace(HTML_DEBRIS_HEAD, "")
+    .replace(HTML_DEBRIS_TAIL, "");
 
   const leadMatch = text.match(/^\s*/);
   const lead = leadMatch?.[0] ?? "";
@@ -60,17 +64,25 @@ export function repairFlavourText(flavour: string): string {
 }
 
 /**
- * Formatting tags upstream leaves behind, including unterminated ones (`</em`).
- * An allowlist rather than a generic tag pattern, which also ate `<sigh>`.
+ * Well-formed tags, which must close. Upstream ships `</e>` among others.
+ * Requiring the `>` keeps `[^>]*` from running to the end of the string.
  */
-const HTML_DEBRIS = /<\/?(?:em|strong|small|span|div|br|b|i|u|p)\b[^>]*>?/gi;
+const HTML_TAG = /<\/?[a-zA-Z][a-zA-Z0-9]*(?:\s[^>]*)?>/g;
 
 /**
- * A closing quote whose attribution starts its own line, which is the shape of
- * the upstream bug. Requiring the newline is what separates it from prose that
- * quotes a word and then uses a dash on the same line.
+ * Truncated debris, which upstream leaves only at the very start or end of the
+ * field (`<em?"I will light our path.`, `...last words</em`). Anchoring is what
+ * stops a bare `<` mid-sentence from eating the rest of the text.
  */
-const ORPHANED_CLOSING_QUOTE = /["”][^\S\n]*\n\s*[-–—]\s*\S/;
+const HTML_DEBRIS_HEAD = /^<\/?[a-zA-Z][a-zA-Z0-9]*[?!]?/;
+const HTML_DEBRIS_TAIL = /<\/?[a-zA-Z][a-zA-Z0-9]*$/;
+
+/**
+ * A closing quote followed by a dashed attribution, on the same line or the
+ * next. Verified against the live card corpus: it fires on 109 flavour texts
+ * and every one is a genuine missing opening quote.
+ */
+const ORPHANED_CLOSING_QUOTE = /["”]\s*(?:\n\s*)*[-–—]\s*\S/;
 
 /** Upstream rules text sometimes ships HTML entities (`&quot;`, `&gt;`, …). */
 export function decodeCardTextEntities(text: string): string {

--- a/packages/types/src/card-text.ts
+++ b/packages/types/src/card-text.ts
@@ -56,14 +56,22 @@ export function repairFlavourText(flavour: string): string {
   const body = text.slice(lead.length);
   if (body.length === 0) return text;
 
+  // Either the field already opens a quote, or its quotes are unbalanced \u2014
+  // which is exactly the shape upstream leaves behind when it drops the opener.
+  // Balanced quotes mean the field is prose containing a quoted word, so a
+  // trailing dash there is punctuation and not an attribution.
+  const opensQuote = body.startsWith('"') || body.startsWith("\u201c");
+  const isDialogue = opensQuote || countQuotes(body) % 2 === 1;
+  if (!isDialogue) return text;
+
   const quoted =
-    body.startsWith('"') || body.startsWith("\u201c")
-      ? body
-      : ORPHANED_CLOSING_QUOTE.test(body)
-        ? `"${body}`
-        : body;
+    opensQuote || !ORPHANED_CLOSING_QUOTE.test(body) ? body : `"${body}`;
 
   return lead + quoted.replace(RUN_ON_ATTRIBUTION, "$1\n$2");
+}
+
+function countQuotes(text: string): number {
+  return text.match(/["\u201c\u201d]/g)?.length ?? 0;
 }
 
 /**
@@ -84,8 +92,13 @@ const HTML_DEBRIS_TAIL = /<\/?[a-zA-Z][a-zA-Z0-9]*$/;
  * A closing quote followed by a dashed attribution, on the same line or the
  * next. Verified against the live card corpus: it fires on 109 flavour texts
  * and every one is a genuine missing opening quote.
+ *
+ * The attribution has to be the last thing in the field. Without that anchor a
+ * quoted word mid-sentence looked like an attribution (`The word "power" - not
+ * a rule.`) and gained a bogus opening quote.
  */
-const ORPHANED_CLOSING_QUOTE = /["”]\s*(?:\n\s*)*[-–—]\s*\S/;
+const ORPHANED_CLOSING_QUOTE =
+  /["”][^\S\n]*(?:\n\s*)*[-–—]\s*\S(?:[^\n]*\S)?\s*$/;
 
 /**
  * A dashed attribution running on after the closing quote (`..." -Azir`).

--- a/packages/types/src/card-text.ts
+++ b/packages/types/src/card-text.ts
@@ -27,6 +27,51 @@ function isUnicodeScalarValue(value: number): boolean {
   );
 }
 
+/**
+ * RiftCodex flavour text systematically drops the opening dialogue quote while
+ * leaving the closer and attribution, e.g.
+ *   If you hit a wall, hit it hard!"\n- Vi
+ * instead of
+ *   "If you hit a wall, hit it hard!"\n- Vi
+ *
+ * Also strips stray HTML tag debris sometimes left in the same field.
+ * Idempotent: already-correct flavours are unchanged.
+ *
+ * Both rules are deliberately narrow, because a false positive silently
+ * corrupts card text this platform is the source of truth for: the quote is
+ * only restored when the attribution sits on its own line, and only known
+ * formatting tags are stripped. Prose that merely quotes a word mid-sentence
+ * and non-HTML angle brackets ("I <3 ...", "<sigh>") are left alone.
+ */
+export function repairFlavourText(flavour: string): string {
+  let text = flavour.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  text = text.replace(HTML_DEBRIS, "");
+
+  const leadMatch = text.match(/^\s*/);
+  const lead = leadMatch?.[0] ?? "";
+  const body = text.slice(lead.length);
+  if (body.length === 0) return text;
+  if (body.startsWith('"') || body.startsWith("\u201c")) return lead + body;
+
+  if (ORPHANED_CLOSING_QUOTE.test(body)) {
+    return `${lead}"${body}`;
+  }
+  return lead + body;
+}
+
+/**
+ * Formatting tags upstream leaves behind, including unterminated ones (`</em`).
+ * An allowlist rather than a generic tag pattern, which also ate `<sigh>`.
+ */
+const HTML_DEBRIS = /<\/?(?:em|strong|small|span|div|br|b|i|u|p)\b[^>]*>?/gi;
+
+/**
+ * A closing quote whose attribution starts its own line, which is the shape of
+ * the upstream bug. Requiring the newline is what separates it from prose that
+ * quotes a word and then uses a dash on the same line.
+ */
+const ORPHANED_CLOSING_QUOTE = /["”][^\S\n]*\n\s*[-–—]\s*\S/;
+
 /** Upstream rules text sometimes ships HTML entities (`&quot;`, `&gt;`, …). */
 export function decodeCardTextEntities(text: string): string {
   let prev = "";

--- a/packages/web/src/views/cards/card-detail-view.tsx
+++ b/packages/web/src/views/cards/card-detail-view.tsx
@@ -272,7 +272,9 @@ function DetailedCardBody({
 
             {card.text?.flavour?.trim() ? (
               <DetailRow label="Flavour" alignTop>
-                <p className="text-muted-foreground text-sm italic">
+                {/* Flavour carries the line break before its attribution
+                    ("…!\n- Vi"), which HTML would otherwise collapse. */}
+                <p className="text-muted-foreground text-sm italic whitespace-pre-line">
                   {card.text.flavour}
                 </p>
               </DetailRow>
@@ -428,7 +430,7 @@ function SimpleCardBody({
         ) : null}
 
         {card.text?.flavour?.trim() ? (
-          <p className="text-muted-foreground mt-6 max-w-prose text-sm italic">
+          <p className="text-muted-foreground mt-6 max-w-prose text-sm italic whitespace-pre-line">
             {card.text.flavour}
           </p>
         ) : null}


### PR DESCRIPTION
> **Stack 4/7** — base `stack/3-admin-ui`. Review only the top three commits; the base PRs carry the rest.

RiftCodex systematically drops the opening dialogue quote from flavour text while keeping the closer and attribution, and sometimes leaves HTML tag debris in the same field:

```
If you hit a wall, hit it hard!"\r\n \r\n- Vi
```

`repairFlavourText()` restores the quote and strips the debris. Idempotent, applied both on ingest (so stored rows are clean) and in `dbRowToCard` (so rows written before this reads correctly).

**Three commits, because the first two were wrong.** The heuristics were then iterated against all 770 cards with flavour text rather than invented examples:

- Requiring the attribution to start its own line skipped the *more common* shape, where it runs on after the closing quote (`"...destiny!" - Azir`) — that regressed 82 of the 109 affected cards. The corpus shows no case where the looser rule fires on anything but a genuine missing quote.
- The tag allowlist missed `</e>`, which upstream actually ships.
- Both tag patterns used a greedy `[^>]*` with an optional `>`, so an unterminated leading tag consumed the whole field: `<em?"I will light our path.` became an empty string. Tags must now close, and truncated debris is stripped only at the very start or end of the field, where upstream leaves it.
- Upstream is inconsistent about attribution placement — own line on 27 cards, inline on 82. The inline form is now normalised to the newline form so both render alike, anchored to end-of-field so a dash *inside* the quoted line is untouched.

The rules are deliberately narrow: a false positive silently corrupts card text this platform is the source of truth for. A generic `<[a-zA-Z]...>` pattern also ate non-HTML brackets like `<sigh>`; matching a dash anywhere after a closing quote also rewrote ordinary prose like `He said "run" - and she ran.` Both cases have regression tests.

Flavour text is also now rendered with `whitespace-pre-line`, so the line break before an attribution survives to the page instead of being collapsed by HTML.

**Verification:** `bun typecheck` clean, `bun test` 438 pass / 0 fail at this commit. Verified across the corpus: 119 cards now render multi-line, every dashed attribution sits on its own line, none are emptied, over-trimmed, double-quoted, or non-idempotent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved card flavour text formatting by restoring missing dialogue quotes, removing stray HTML, and separating attribution text.
  * Preserved line breaks when displaying flavour text in card details.
  * Applied consistent formatting to imported and stored card data.
* **Bug Fixes**
  * Prevented empty flavour text from being displayed unnecessarily.
* **Tests**
  * Added coverage for quote restoration, attribution formatting, HTML removal, dash handling, and repeated formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->